### PR TITLE
feat: add hidden --demo flag for MockClient

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -124,4 +124,15 @@ func initJaraFlags() {
 		"",
 		"Override the default view/command on launch",
 	)
+
+	// Demo mode (hidden) — use MockClient instead of a real Juju connection.
+	var demo bool
+	jaraFlags.Demo = &demo
+	rootCmd.Flags().BoolVar(
+		jaraFlags.Demo,
+		"demo",
+		false,
+		"Use synthetic mock data instead of a live Juju connection",
+	)
+	_ = rootCmd.Flags().MarkHidden("demo")
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -44,12 +44,18 @@ func run(_ *cobra.Command, _ []string) error {
 	theme := config.ResolveTheme(cfg.Jara.UI.Skin)
 	keys := config.ResolveKeyMap(cfg.Jara.UI.Keys)
 
-	// 5. Connect to Juju.
-	client, err := api.NewJujuClient(api.WithCharmhubURL(cfg.Jara.CharmhubURL))
-	if err != nil {
-		return fmt.Errorf("creating Juju client: %w", err)
+	// 5. Connect to Juju (or use mock data in demo mode).
+	var client api.Client
+	if jaraFlags.Demo != nil && *jaraFlags.Demo {
+		client = api.NewMockClient()
+	} else {
+		jujuClient, err := api.NewJujuClient(api.WithCharmhubURL(cfg.Jara.CharmhubURL))
+		if err != nil {
+			return fmt.Errorf("creating Juju client: %w", err)
+		}
+		defer func() { _ = jujuClient.Close() }()
+		client = jujuClient
 	}
-	defer func() { _ = client.Close() }()
 
 	// 6. Build and run the TUI.
 	m := app.New(client, app.WithTheme(theme), app.WithKeyMap(keys), app.WithConfig(cfg), app.WithVersion(version))

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -11,6 +11,7 @@ type Flags struct {
 	ReadOnly    *bool
 	Command     *string
 	ConfigFile  *string
+	Demo        *bool
 }
 
 // NewFlags returns a Flags struct with all nil pointers (nothing overridden).


### PR DESCRIPTION
Add a Demo field to config.Flags and register a hidden --demo CLI flag. When set, the run command uses api.NewMockClient() instead of connecting to a live Juju controller. This enables VHS integration tests and local demos without requiring a real Juju environment.

Related to #10