### PR TITLE
fix: close relate modal on Esc regardless of editing state

### DIFF
--- a/internal/view/relatemodal/modal.go
+++ b/internal/view/relatemodal/modal.go
@@ -206,11 +206,7 @@ func (m *Modal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// On endpoint B, try to apply.
 				return m.tryApply()
 			case key.Matches(kp, m.keys.Back):
-				m.editing = false
-				m.autocomplete = nil
-				m.autocompleteIndex = 0
-				m.input.Blur()
-				return m, nil
+				return m, func() tea.Msg { return ClosedMsg{} }
 			}
 		}
 		var cmd tea.Cmd

--- a/tests/vhs/golden/modal_relate_escape.ascii
+++ b/tests/vhs/golden/modal_relate_escape.ascii
@@ -1,0 +1,546 @@
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./jara --demo
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./jara --demo
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./jara --demo
+╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                                   │
+│                                    <enter> select  <+/-> scale                         ██╗ █████╗ ██████╗  █████╗ │
+│Controller: prod-aws                <D> deploy      <L> logs (app)                      ██║██╔══██╗██╔══██╗██╔══██╗│
+│Model:                              <r> relate      <l> logs                            ██║███████║██████╔╝███████║│
+│Cloud:      /                       <A> apps        <:> cmd                        ██   ██║██╔══██║██╔══██╗██╔══██║│
+│Juju:                               <U> units       <?> help                       ╚█████╔╝██║  ██║██║  ██║██║  ██║│
+│Jara:       test                    <R> relations   <q> quit                        ╚════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝│
+╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────── Applications ───────────────────────────╮╭─────────────────── Units ───────────────────╮
+│ NAME      STATUS  CHARM      CHANN…  R…  S…  EX…  MESSAGE          ││ UNIT         WORK…  AGENT  MESSAGE          │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    │╰─────────────────────────────────────────────╯
+│                                                                    │╭───────────────── Relations ─────────────────╮
+│                                                                    ││ RELATION                                    │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+╰────────────────────────────────────────────────────────────────────╯╰─────────────────────────────────────────────╯
+
+
+  Model
+────────────────────────────────────────────────────────────────────────────────
+> ./jara --demo
+╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                                   │
+│                                      <enter> select  <+/-> scale                       ██╗ █████╗ ██████╗  █████╗ │
+│Controller: prod-aws                  <D> deploy      <L> logs (app)                    ██║██╔══██╗██╔══██╗██╔══██╗│
+│Model:      production                <r> relate      <l> logs                          ██║███████║██████╔╝███████║│
+│Cloud:      aws/us-east-1             <A> apps        <:> cmd                      ██   ██║██╔══██║██╔══██╗██╔══██║│
+│Juju:       3.6.1                     <U> units       <?> help                     ╚█████╔╝██║  ██║██║  ██║██║  ██║│
+│Jara:       test                      <R> relations   <q> quit                      ╚════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝│
+╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────── Applications ───────────────────────────╮╭────────────── Units(grafana) ───────────────╮
+│ NAME      STATUS  CHARM      CHANN…  R…  S…  EX…  MESSAGE          ││ UNIT         WORK…  AGENT  MESSAGE          │
+│ grafana   block…  grafana-…  lates…  1…  1   no   Missing relatio… ││ ★ grafana/0  bloc…  idle   Missing relatio… │
+│ nginx-i…  active  nginx-in…  lates…  95  1   yes  Ingress ready    ││                                             │
+│ postgre…  active  postgres…  14/st…  4…  3   no   Live master (14… ││                                             │
+│ prometh…  waiti…  promethe…  lates…  1…  1   no   Waiting for rel… ││                                             │
+│ ubuntu-…  active  ubuntu     stable  24  2   yes  Ready            ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    │╰─────────────────────────────────────────────╯
+│                                                                    │╭──────────── Relations(grafana) ─────────────╮
+│                                                                    ││ RELATION                                    │
+│                                                                    ││ grafana:grafana-source -> prometheus:grafa… │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+╰────────────────────────────────────────────────────────────────────╯╰─────────────────────────────────────────────╯
+
+
+  Model
+────────────────────────────────────────────────────────────────────────────────
+> ./jara --demo
+╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                                   │
+│                                      <enter> select  <+/-> scale                       ██╗ █████╗ ██████╗  █████╗ │
+│Controller: prod-aws                  <D> deploy      <L> logs (app)                    ██║██╔══██╗██╔══██╗██╔══██╗│
+│Model:      production                <r> relate      <l> logs                          ██║███████║██████╔╝███████║│
+│Cloud:      aws/us-east-1             <A> apps        <:> cmd                      ██   ██║██╔══██║██╔══██╗██╔══██║│
+│Juju:       3.6.1                     <U> units       <?> help                     ╚█████╔╝██║  ██║██║  ██║██║  ██║│
+│Jara:       test                      <R> relations   <q> quit                      ╚════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝│
+╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────── Applications ───────────────────────────╮╭────────────── Units(grafana) ───────────────╮
+│ NAME      STATUS  CHARM      CHANN…  R…  S…  EX…  MESSAGE          ││ UNIT         WORK…  AGENT  MESSAGE          │
+│ grafana   block…  grafana-…  lates…  1…  1   no   Missing relatio… ││ ★ grafana/0  bloc…  idle   Missing relatio… │
+│ nginx-i…  active  nginx-in…  lates…  95  1   yes  Ingress ready    ││                                             │
+│ postgre…  active  postgres…  14/st…  4…  3   no   Live master (14… ││                                             │
+│ prometh…  waiti…  promethe…  lates…  1…  1   no   Waiting for rel… ││                                             │
+│ ubuntu-…  active  ubuntu    ╭──────────────────── Add Relation ────────────────────╮                              │
+│                             │Endpoint A                                            │                              │
+│                             │  grafana                                             │                              │
+│                             │                                                      │                              │
+│                             │▶ Endpoint B                                          │                              │
+│                             │  █                                                   │                              │
+│                             │  grafana                                             │                              │
+│                             │  grafana:database                      requirer      │──────────────────────────────╯
+│                             │  grafana:grafana-source                requirer      │lations(grafana) ─────────────╮
+│                             │  grafana:ingress                       requirer      │                              │
+│                             │  nginx-ingress                                       │a-source -> prometheus:grafa… │
+│                             │  nginx-ingress:ingress                 provider      │                              │
+│                             │  nginx-ingress:ingress-proxy           provider      │                              │
+│                             │  postgresql                                          │                              │
+│                             │Tab next  •  Enter relate  •  Esc close               │                              │
+│                             ╰──────────────────────────────────────────────────────╯                              │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+╰────────────────────────────────────────────────────────────────────╯╰─────────────────────────────────────────────╯
+
+
+  Model
+────────────────────────────────────────────────────────────────────────────────
+> ./jara --demo
+╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                                   │
+│                                      <enter> select  <+/-> scale                       ██╗ █████╗ ██████╗  █████╗ │
+│Controller: prod-aws                  <D> deploy      <L> logs (app)                    ██║██╔══██╗██╔══██╗██╔══██╗│
+│Model:      production                <r> relate      <l> logs                          ██║███████║██████╔╝███████║│
+│Cloud:      aws/us-east-1             <A> apps        <:> cmd                      ██   ██║██╔══██║██╔══██╗██╔══██║│
+│Juju:       3.6.1                     <U> units       <?> help                     ╚█████╔╝██║  ██║██║  ██║██║  ██║│
+│Jara:       test                      <R> relations   <q> quit                      ╚════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝│
+╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────── Applications ───────────────────────────╮╭────────────── Units(grafana) ───────────────╮
+│ NAME      STATUS  CHARM      CHANN…  R…  S…  EX…  MESSAGE          ││ UNIT         WORK…  AGENT  MESSAGE          │
+│ grafana   block…  grafana-…  lates…  1…  1   no   Missing relatio… ││ ★ grafana/0  bloc…  idle   Missing relatio… │
+│ nginx-i…  active  nginx-in…  lates…  95  1   yes  Ingress ready    ││                                             │
+│ postgre…  active  postgres…  14/st…  4…  3   no   Live master (14… ││                                             │
+│ prometh…  waiti…  promethe…  lates…  1…  1   no   Waiting for rel… ││                                             │
+│ ubuntu-…  active  ubuntu    ╭──────────────────── Add Relation ────────────────────╮                              │
+│                             │Endpoint A                                            │                              │
+│                             │  grafana                                             │                              │
+│                             │                                                      │                              │
+│                             │▶ Endpoint B                                          │                              │
+│                             │  █                                                   │                              │
+│                             │  grafana                                             │                              │
+│                             │  grafana:database                      requirer      │──────────────────────────────╯
+│                             │  grafana:grafana-source                requirer      │lations(grafana) ─────────────╮
+│                             │  grafana:ingress                       requirer      │                              │
+│                             │  nginx-ingress                                       │a-source -> prometheus:grafa… │
+│                             │  nginx-ingress:ingress                 provider      │                              │
+│                             │  nginx-ingress:ingress-proxy           provider      │                              │
+│                             │  postgresql                                          │                              │
+│                             │Tab next  •  Enter relate  •  Esc close               │                              │
+│                             ╰──────────────────────────────────────────────────────╯                              │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+╰────────────────────────────────────────────────────────────────────╯╰─────────────────────────────────────────────╯
+
+
+  Model
+────────────────────────────────────────────────────────────────────────────────
+> ./jara --demo
+╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                                   │
+│                                      <enter> select  <+/-> scale                       ██╗ █████╗ ██████╗  █████╗ │
+│Controller: prod-aws                  <D> deploy      <L> logs (app)                    ██║██╔══██╗██╔══██╗██╔══██╗│
+│Model:      production                <r> relate      <l> logs                          ██║███████║██████╔╝███████║│
+│Cloud:      aws/us-east-1             <A> apps        <:> cmd                      ██   ██║██╔══██║██╔══██╗██╔══██║│
+│Juju:       3.6.1                     <U> units       <?> help                     ╚█████╔╝██║  ██║██║  ██║██║  ██║│
+│Jara:       test                      <R> relations   <q> quit                      ╚════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝│
+╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────── Applications ───────────────────────────╮╭────────────── Units(grafana) ───────────────╮
+│ NAME      STATUS  CHARM      CHANN…  R…  S…  EX…  MESSAGE          ││ UNIT         WORK…  AGENT  MESSAGE          │
+│ grafana   block…  grafana-…  lates…  1…  1   no   Missing relatio… ││ ★ grafana/0  bloc…  idle   Missing relatio… │
+│ nginx-i…  active  nginx-in…  lates…  95  1   yes  Ingress ready    ││                                             │
+│ postgre…  active  postgres…  14/st…  4…  3   no   Live master (14… ││                                             │
+│ prometh…  waiti…  promethe…  lates…  1…  1   no   Waiting for rel… ││                                             │
+│ ubuntu-…  active  ubuntu    ╭──────────────────── Add Relation ────────────────────╮                              │
+│                             │Endpoint A                                            │                              │
+│                             │  grafana                                             │                              │
+│                             │                                                      │                              │
+│                             │▶ Endpoint B                                          │                              │
+│                             │  █                                                   │                              │
+│                             │  grafana                                             │                              │
+│                             │  grafana:database                      requirer      │──────────────────────────────╯
+│                             │  grafana:grafana-source                requirer      │lations(grafana) ─────────────╮
+│                             │  grafana:ingress                       requirer      │                              │
+│                             │  nginx-ingress                                       │a-source -> prometheus:grafa… │
+│                             │  nginx-ingress:ingress                 provider      │                              │
+│                             │  nginx-ingress:ingress-proxy           provider      │                              │
+│                             │  postgresql                                          │                              │
+│                             │Tab next  •  Enter relate  •  Esc close               │                              │
+│                             ╰──────────────────────────────────────────────────────╯                              │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+╰────────────────────────────────────────────────────────────────────╯╰─────────────────────────────────────────────╯
+
+
+  Model
+────────────────────────────────────────────────────────────────────────────────
+> ./jara --demo
+╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                                   │
+│                                      <enter> select  <+/-> scale                       ██╗ █████╗ ██████╗  █████╗ │
+│Controller: prod-aws                  <D> deploy      <L> logs (app)                    ██║██╔══██╗██╔══██╗██╔══██╗│
+│Model:      production                <r> relate      <l> logs                          ██║███████║██████╔╝███████║│
+│Cloud:      aws/us-east-1             <A> apps        <:> cmd                      ██   ██║██╔══██║██╔══██╗██╔══██║│
+│Juju:       3.6.1                     <U> units       <?> help                     ╚█████╔╝██║  ██║██║  ██║██║  ██║│
+│Jara:       test                      <R> relations   <q> quit                      ╚════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝│
+╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────── Applications ───────────────────────────╮╭────────────── Units(grafana) ───────────────╮
+│ NAME      STATUS  CHARM      CHANN…  R…  S…  EX…  MESSAGE          ││ UNIT         WORK…  AGENT  MESSAGE          │
+│ grafana   block…  grafana-…  lates…  1…  1   no   Missing relatio… ││ ★ grafana/0  bloc…  idle   Missing relatio… │
+│ nginx-i…  active  nginx-in…  lates…  95  1   yes  Ingress ready    ││                                             │
+│ postgre…  active  postgres…  14/st…  4…  3   no   Live master (14… ││                                             │
+│ prometh…  waiti…  promethe…  lates…  1…  1   no   Waiting for rel… ││                                             │
+│ ubuntu-…  active  ubuntu    ╭──────────────────── Add Relation ────────────────────╮                              │
+│                             │Endpoint A                                            │                              │
+│                             │  grafana                                             │                              │
+│                             │                                                      │                              │
+│                             │▶ Endpoint B                                          │                              │
+│                             │  █                                                   │                              │
+│                             │  grafana                                             │                              │
+│                             │  grafana:database                      requirer      │──────────────────────────────╯
+│                             │  grafana:grafana-source                requirer      │lations(grafana) ─────────────╮
+│                             │  grafana:ingress                       requirer      │                              │
+│                             │  nginx-ingress                                       │a-source -> prometheus:grafa… │
+│                             │  nginx-ingress:ingress                 provider      │                              │
+│                             │  nginx-ingress:ingress-proxy           provider      │                              │
+│                             │  postgresql                                          │                              │
+│                             │Tab next  •  Enter relate  •  Esc close               │                              │
+│                             ╰──────────────────────────────────────────────────────╯                              │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+╰────────────────────────────────────────────────────────────────────╯╰─────────────────────────────────────────────╯
+
+
+  Model
+────────────────────────────────────────────────────────────────────────────────
+> ./jara --demo
+╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                                   │
+│                                      <enter> select  <+/-> scale                       ██╗ █████╗ ██████╗  █████╗ │
+│Controller: prod-aws                  <D> deploy      <L> logs (app)                    ██║██╔══██╗██╔══██╗██╔══██╗│
+│Model:      production                <r> relate      <l> logs                          ██║███████║██████╔╝███████║│
+│Cloud:      aws/us-east-1             <A> apps        <:> cmd                      ██   ██║██╔══██║██╔══██╗██╔══██║│
+│Juju:       3.6.1                     <U> units       <?> help                     ╚█████╔╝██║  ██║██║  ██║██║  ██║│
+│Jara:       test                      <R> relations   <q> quit                      ╚════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝│
+╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────── Applications ───────────────────────────╮╭────────────── Units(grafana) ───────────────╮
+│ NAME      STATUS  CHARM      CHANN…  R…  S…  EX…  MESSAGE          ││ UNIT         WORK…  AGENT  MESSAGE          │
+│ grafana   block…  grafana-…  lates…  1…  1   no   Missing relatio… ││ ★ grafana/0  bloc…  idle   Missing relatio… │
+│ nginx-i…  active  nginx-in…  lates…  95  1   yes  Ingress ready    ││                                             │
+│ postgre…  active  postgres…  14/st…  4…  3   no   Live master (14… ││                                             │
+│ prometh…  waiti…  promethe…  lates…  1…  1   no   Waiting for rel… ││                                             │
+│ ubuntu-…  active  ubuntu     stable  24  2   yes  Ready            ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    │╰─────────────────────────────────────────────╯
+│                                                                    │╭──────────── Relations(grafana) ─────────────╮
+│                                                                    ││ RELATION                                    │
+│                                                                    ││ grafana:grafana-source -> prometheus:grafa… │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+╰────────────────────────────────────────────────────────────────────╯╰─────────────────────────────────────────────╯
+
+
+  Model
+────────────────────────────────────────────────────────────────────────────────
+> ./jara --demo
+╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                                   │
+│                                      <enter> select  <+/-> scale                       ██╗ █████╗ ██████╗  █████╗ │
+│Controller: prod-aws                  <D> deploy      <L> logs (app)                    ██║██╔══██╗██╔══██╗██╔══██╗│
+│Model:      production                <r> relate      <l> logs                          ██║███████║██████╔╝███████║│
+│Cloud:      aws/us-east-1             <A> apps        <:> cmd                      ██   ██║██╔══██║██╔══██╗██╔══██║│
+│Juju:       3.6.1                     <U> units       <?> help                     ╚█████╔╝██║  ██║██║  ██║██║  ██║│
+│Jara:       test                      <R> relations   <q> quit                      ╚════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝│
+╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────── Applications ───────────────────────────╮╭────────────── Units(grafana) ───────────────╮
+│ NAME      STATUS  CHARM      CHANN…  R…  S…  EX…  MESSAGE          ││ UNIT         WORK…  AGENT  MESSAGE          │
+│ grafana   block…  grafana-…  lates…  1…  1   no   Missing relatio… ││ ★ grafana/0  bloc…  idle   Missing relatio… │
+│ nginx-i…  active  nginx-in…  lates…  95  1   yes  Ingress ready    ││                                             │
+│ postgre…  active  postgres…  14/st…  4…  3   no   Live master (14… ││                                             │
+│ prometh…  waiti…  promethe…  lates…  1…  1   no   Waiting for rel… ││                                             │
+│ ubuntu-…  active  ubuntu     stable  24  2   yes  Ready            ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    │╰─────────────────────────────────────────────╯
+│                                                                    │╭──────────── Relations(grafana) ─────────────╮
+│                                                                    ││ RELATION                                    │
+│                                                                    ││ grafana:grafana-source -> prometheus:grafa… │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+╰────────────────────────────────────────────────────────────────────╯╰─────────────────────────────────────────────╯
+
+
+  Model
+────────────────────────────────────────────────────────────────────────────────
+> ./jara --demo
+╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                                   │
+│                                      <enter> select  <+/-> scale                       ██╗ █████╗ ██████╗  █████╗ │
+│Controller: prod-aws                  <D> deploy      <L> logs (app)                    ██║██╔══██╗██╔══██╗██╔══██╗│
+│Model:      production                <r> relate      <l> logs                          ██║███████║██████╔╝███████║│
+│Cloud:      aws/us-east-1             <A> apps        <:> cmd                      ██   ██║██╔══██║██╔══██╗██╔══██║│
+│Juju:       3.6.1                     <U> units       <?> help                     ╚█████╔╝██║  ██║██║  ██║██║  ██║│
+│Jara:       test                      <R> relations   <q> quit                      ╚════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝│
+╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────── Applications ───────────────────────────╮╭────────────── Units(grafana) ───────────────╮
+│ NAME      STATUS  CHARM      CHANN…  R…  S…  EX…  MESSAGE          ││ UNIT         WORK…  AGENT  MESSAGE          │
+│ grafana   block…  grafana-…  lates…  1…  1   no   Missing relatio… ││ ★ grafana/0  bloc…  idle   Missing relatio… │
+│ nginx-i…  active  nginx-in…  lates…  95  1   yes  Ingress ready    ││                                             │
+│ postgre…  active  postgres…  14/st…  4…  3   no   Live master (14… ││                                             │
+│ prometh…  waiti…  promethe…  lates…  1…  1   no   Waiting for rel… ││                                             │
+│ ubuntu-…  active  ubuntu     stable  24  2   yes  Ready            ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    │╰─────────────────────────────────────────────╯
+│                                                                    │╭──────────── Relations(grafana) ─────────────╮
+│                                                                    ││ RELATION                                    │
+│                                                                    ││ grafana:grafana-source -> prometheus:grafa… │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+╰────────────────────────────────────────────────────────────────────╯╰─────────────────────────────────────────────╯
+
+
+  Model
+────────────────────────────────────────────────────────────────────────────────
+> ./jara --demo
+╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                                   │
+│                                      <enter> select  <+/-> scale                       ██╗ █████╗ ██████╗  █████╗ │
+│Controller: prod-aws                  <D> deploy      <L> logs (app)                    ██║██╔══██╗██╔══██╗██╔══██╗│
+│Model:      production                <r> relate      <l> logs                          ██║███████║██████╔╝███████║│
+│Cloud:      aws/us-east-1             <A> apps        <:> cmd                      ██   ██║██╔══██║██╔══██╗██╔══██║│
+│Juju:       3.6.1                     <U> units       <?> help                     ╚█████╔╝██║  ██║██║  ██║██║  ██║│
+│Jara:       test                      <R> relations   <q> quit                      ╚════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝│
+╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────── Applications ───────────────────────────╮╭────────────── Units(grafana) ───────────────╮
+│ NAME      STATUS  CHARM      CHANN…  R…  S…  EX…  MESSAGE          ││ UNIT         WORK…  AGENT  MESSAGE          │
+│ grafana   block…  grafana-…  lates…  1…  1   no   Missing relatio… ││ ★ grafana/0  bloc…  idle   Missing relatio… │
+│ nginx-i…  active  nginx-in…  lates…  95  1   yes  Ingress ready    ││                                             │
+│ postgre…  active  postgres…  14/st…  4…  3   no   Live master (14… ││                                             │
+│ prometh…  waiti…  promethe…  lates…  1…  1   no   Waiting for rel… ││                                             │
+│ ubuntu-…  active  ubuntu     stable  24  2   yes  Ready            ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    │╰─────────────────────────────────────────────╯
+│                                                                    │╭──────────── Relations(grafana) ─────────────╮
+│                                                                    ││ RELATION                                    │
+│                                                                    ││ grafana:grafana-source -> prometheus:grafa… │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+│                                                                    ││                                             │
+╰────────────────────────────────────────────────────────────────────╯╰─────────────────────────────────────────────╯
+
+
+  Model
+────────────────────────────────────────────────────────────────────────────────

--- a/tests/vhs/modal_relate_escape.tape
+++ b/tests/vhs/modal_relate_escape.tape
@@ -1,0 +1,34 @@
+# modal_relate_escape.tape — open the relate modal from model view and dismiss it with Esc.
+# Verifies that Esc closes the modal and stays on the model view (does not navigate back).
+
+Source tests/vhs/_setup.tape
+
+Output tests/vhs/golden/modal_relate_escape.ascii
+
+Type "./jara --demo"
+Enter
+
+# Wait for model detail view to render.
+Wait+Screen /Applications/
+
+Sleep 1s
+
+# Open the relate modal with the 'r' key.
+Type "r"
+
+# Wait for the modal to appear.
+Wait+Screen /Add Relation/
+
+Sleep 1s
+
+# Press Esc — should close the modal and stay on the model view.
+Escape
+
+# The model view should still be visible (not the models list).
+Wait+Screen /Applications/
+
+Sleep 1s
+
+Type "q"
+
+Sleep 500ms


### PR DESCRIPTION
When the user presses Esc (Back key) while the text input is focused in the relate modal, the modal now emits ClosedMsg and dismisses entirely. Previously it only blurred the input, leaving the modal open in a non-editing state — a subsequent Esc then leaked through to the parent view and triggered back-navigation to the models list.

Add tests/vhs/modal_relate_escape.tape and its golden file to cover the models → modelview → relate modal → Esc → stays on modelview flow.