### PR TITLE
fix: code quality improvements for type safety, error handling, and credentials

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -391,7 +391,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m Model) updateActiveView(msg tea.Msg) (Model, tea.Cmd) {
 	currentView := m.views[m.stack.Current().View]
 	updated, cmd := currentView.Update(msg)
-	m.views[m.stack.Current().View] = updated.(view.View)
+	if v, ok := updated.(view.View); ok {
+		m.views[m.stack.Current().View] = v
+	}
 	return m, cmd
 }
 
@@ -645,7 +647,8 @@ func initLLMClient(cfg *config.Config) (llm.Client, error) {
 			return nil, err
 		}
 		return c, nil
-	}
 
-	return nil, nil
+	default:
+		return nil, fmt.Errorf("unknown AI provider: %q (supported: copilot, gemini)", provider)
+	}
 }

--- a/internal/app/statusstream.go
+++ b/internal/app/statusstream.go
@@ -67,8 +67,7 @@ func (m *Model) startStatusStream() tea.Cmd {
 	return func() tea.Msg {
 		ch, err := client.WatchStatus(ctx, refreshDuration)
 		if err != nil {
-			if strings.Contains(err.Error(), "No selected model") ||
-				strings.Contains(err.Error(), "resolving current model") {
+			if isNoModelError(err) {
 				return modelview.NoModelMsg{}
 			}
 			return errMsg{err}
@@ -98,7 +97,7 @@ func readNextStatus(ctx context.Context, ch <-chan api.StatusUpdate) tea.Cmd {
 				return errMsg{err: fmt.Errorf("status stream closed")}
 			}
 			if update.Err != nil {
-				if strings.Contains(update.Err.Error(), "No selected model") {
+				if isNoModelError(update.Err) {
 					return modelview.NoModelMsg{}
 				}
 				return statusStreamErrMsg{err: update.Err, ctx: ctx, ch: ch}
@@ -304,4 +303,16 @@ func (m Model) fetchRelationData(relationID int) tea.Cmd {
 		}
 		return relations.RelationDataMsg{RelationID: relationID, Data: data}
 	}
+}
+
+// isNoModelError checks whether the error indicates that no Juju model is
+// currently selected. This centralises the (fragile) string-based detection
+// so it can be tested and updated in a single place.
+func isNoModelError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "No selected model") ||
+		strings.Contains(msg, "resolving current model")
 }

--- a/internal/app/statusstream_test.go
+++ b/internal/app/statusstream_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"charm.land/bubbles/v2/key"
@@ -72,8 +73,27 @@ func TestDeployApplicationTargetsModel(t *testing.T) {
 	}
 }
 
-// TestBuildHeaderHints verifies the 12-hint cap (2 columns), view-specific priority, and
-// that the help hint is always the last element.
+func TestIsNoModelError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"unrelated error", fmt.Errorf("connection refused"), false},
+		{"no selected model", fmt.Errorf("No selected model"), true},
+		{"resolving current model", fmt.Errorf("error resolving current model"), true},
+		{"wrapped no selected model", fmt.Errorf("status: %w", fmt.Errorf("No selected model")), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNoModelError(tt.err); got != tt.want {
+				t.Errorf("isNoModelError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildHeaderHints(t *testing.T) {
 	m := Model{keys: ui.DefaultKeyMap()}
 

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -13,13 +13,15 @@ import (
 //
 // Lookup order:
 //
-//	copilot: GITHUB_TOKEN env → gh CLI hosts.yml (github.com oauth_token)
+//	copilot: GITHUB_TOKEN → GH_TOKEN → COPILOT_GITHUB_TOKEN → gh CLI hosts.yml
 //	gemini:  GOOGLE_AI_API_KEY env → GEMINI_API_KEY env
 func LoadAICredential(provider string) string {
 	switch strings.ToLower(provider) {
 	case "copilot", "":
-		if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
-			return tok
+		for _, env := range []string{"GITHUB_TOKEN", "GH_TOKEN", "COPILOT_GITHUB_TOKEN"} {
+			if tok := os.Getenv(env); tok != "" {
+				return tok
+			}
 		}
 		return ghCLIToken()
 	case "gemini":

--- a/internal/config/credentials_test.go
+++ b/internal/config/credentials_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestLoadAICredentialCopilotEnvVars(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVars map[string]string
+		want    string
+	}{
+		{
+			name:    "GITHUB_TOKEN takes priority",
+			envVars: map[string]string{"GITHUB_TOKEN": "gh-tok", "GH_TOKEN": "alt-tok"},
+			want:    "gh-tok",
+		},
+		{
+			name:    "GH_TOKEN used when GITHUB_TOKEN empty",
+			envVars: map[string]string{"GH_TOKEN": "alt-tok"},
+			want:    "alt-tok",
+		},
+		{
+			name:    "COPILOT_GITHUB_TOKEN used as fallback",
+			envVars: map[string]string{"COPILOT_GITHUB_TOKEN": "cp-tok"},
+			want:    "cp-tok",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear all copilot-related env vars.
+			for _, k := range []string{"GITHUB_TOKEN", "GH_TOKEN", "COPILOT_GITHUB_TOKEN"} {
+				t.Setenv(k, "")
+			}
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+			got := LoadAICredential("copilot")
+			if got != tt.want {
+				t.Errorf("LoadAICredential(copilot) = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadAICredentialUnknownProvider(t *testing.T) {
+	got := LoadAICredential("openai")
+	if got != "" {
+		t.Errorf("LoadAICredential(openai) = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
Fixes #26, #27, #30, #33

## Changes

- **Safe type assertion** (#26): Use comma-ok idiom in `updateActiveView` to prevent potential panic when a view's `Update` method returns an unexpected type.

- **Error on unknown AI provider** (#27): `initLLMClient` now returns a descriptive error for unrecognized provider names instead of silently returning `nil, nil`.

- **Centralised no-model error detection** (#33): Extract the fragile string-based error matching into a testable `isNoModelError` helper function, used by both `startStatusStream` and `readNextStatus`.

- **Credential env var support** (#30): `LoadAICredential` now checks `GH_TOKEN` and `COPILOT_GITHUB_TOKEN` in addition to `GITHUB_TOKEN`, matching the documented behaviour in `copilot.go`.

- **Tests**: Added `TestIsNoModelError` and `TestLoadAICredentialCopilotEnvVars` / `TestLoadAICredentialUnknownProvider`.

### Closed as not-a-bug
- #28: `log.Printf` calls in `juju.go` are safe — stdlib log is redirected to a file via `setupLogging` before the TUI starts.
- #29: `GeminiClient.Close()` is a no-op because `genai.Client` has no `Close()` method in the current SDK version.