### PR TITLE
feat(nav): add M keyboard shortcut for machines view

### DIFF
--- a/internal/app/input.go
+++ b/internal/app/input.go
@@ -239,6 +239,9 @@ func (m Model) handleGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 	case key.Matches(msg, m.keys.SecretsNav):
 		m2, cmd := m.handleNavigate(view.NavigateMsg{Target: nav.SecretsView})
 		return m2, cmd, true
+	case key.Matches(msg, m.keys.MachinesNav):
+		m2, cmd := m.handleNavigate(view.NavigateMsg{Target: nav.MachinesView})
+		return m2, cmd, true
 	case key.Matches(msg, m.keys.ChatNav):
 		m2, cmd := m.handleNavigate(view.NavigateMsg{Target: nav.ChatView})
 		return m2, cmd, true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -223,6 +223,7 @@ type KeysConfig struct {
 	ApplicationsNav *KeyBindingConfig `yaml:"applicationsNav,omitempty"`
 	RelationsNav    *KeyBindingConfig `yaml:"relationsNav,omitempty"`
 	SecretsNav      *KeyBindingConfig `yaml:"secretsNav,omitempty"`
+	MachinesNav     *KeyBindingConfig `yaml:"machinesNav,omitempty"`
 	Decode          *KeyBindingConfig `yaml:"decode,omitempty"`
 	ApplyFilter     *KeyBindingConfig `yaml:"applyFilter,omitempty"`
 	Right           *KeyBindingConfig `yaml:"right,omitempty"`

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -41,6 +41,7 @@ func ResolveKeyMap(keys KeysConfig) ui.KeyMap {
 	overrideBinding(&km.ApplicationsNav, keys.ApplicationsNav, "applications")
 	overrideBinding(&km.RelationsNav, keys.RelationsNav, "relations")
 	overrideBinding(&km.SecretsNav, keys.SecretsNav, "secrets")
+	overrideBinding(&km.MachinesNav, keys.MachinesNav, "machines")
 	overrideBinding(&km.Decode, keys.Decode, "decode")
 	overrideBinding(&km.ApplyFilter, keys.ApplyFilter, "apply")
 	overrideBinding(&km.Right, keys.Right, "right")

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -36,6 +36,7 @@ type KeyMap struct {
 	ApplicationsNav key.Binding // Shift+A: navigate to applications view
 	RelationsNav    key.Binding // Shift+R: navigate to relations view
 	SecretsNav      key.Binding // Shift+S: navigate to secrets view
+	MachinesNav     key.Binding // Shift+M: navigate to machines view
 	Decode          key.Binding // d: decode/reveal secret content
 	ApplyFilter     key.Binding // Shift+F: apply filter in modal
 	Right           key.Binding // l/right: move right in modal
@@ -165,6 +166,10 @@ func DefaultKeyMap() KeyMap {
 		SecretsNav: key.NewBinding(
 			key.WithKeys("S"),
 			key.WithHelp("S", "secrets"),
+		),
+		MachinesNav: key.NewBinding(
+			key.WithKeys("M"),
+			key.WithHelp("M", "machines"),
 		),
 		Decode: key.NewBinding(
 			key.WithKeys("d"),

--- a/internal/view/modelview/view.go
+++ b/internal/view/modelview/view.go
@@ -193,6 +193,10 @@ func (m *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, func() tea.Msg {
 				return view.NavigateMsg{Target: nav.RelationsView}
 			}
+		case key.Matches(msg, m.keys.MachinesNav):
+			return m, func() tea.Msg {
+				return view.NavigateMsg{Target: nav.MachinesView}
+			}
 		case key.Matches(msg, m.keys.LogsJump):
 			var filter *model.DebugLogFilter
 			if m.selectedApp != "" {


### PR DESCRIPTION
Fixes #21

The machines view was already registered and accessible via `:machines` command, but lacked a keyboard shortcut for consistency with other views.

## Changes
- Add `MachinesNav` key binding (`Shift+M`) to `KeyMap`
- Wire global key handler in `handleGlobalKeys`
- Add `M` shortcut in model overview for direct navigation
- Add key hint in model overview header
- Add config override support for `machinesNav` key binding

Now all main views have consistent Shift+letter shortcuts: **A**pps, **U**nits, **R**elations, **S**ecrets, **M**achines.