### PR TITLE
fix(api): replace string-based error matching with sentinel ErrNoSelectedModel

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -5,10 +5,16 @@ package api
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/bschimke95/jara/internal/model"
 )
+
+// ErrNoSelectedModel is returned when a Juju operation requires a model but
+// none is currently selected (e.g. the user has not yet run `juju switch`).
+// Callers should check for this with errors.Is(err, ErrNoSelectedModel).
+var ErrNoSelectedModel = errors.New("no selected model")
 
 // Client defines the interface for fetching Juju status.
 type Client interface {

--- a/internal/api/juju.go
+++ b/internal/api/juju.go
@@ -290,7 +290,7 @@ func (c *JujuClient) connect(ctx context.Context) (api.Connection, error) {
 		// Resolve the current model for this controller from the client store.
 		modelName, err := c.store.CurrentModel(c.controllerName)
 		if err != nil {
-			return nil, fmt.Errorf("resolving current model for controller %q: %w", c.controllerName, err)
+			return nil, fmt.Errorf("resolving current model for controller %q: %w", c.controllerName, fmt.Errorf("%s: %w", err.Error(), ErrNoSelectedModel))
 		}
 		modelDetails, err := c.store.ModelByName(c.controllerName, modelName)
 		if err != nil {
@@ -847,7 +847,7 @@ func (c *JujuClient) ListOffers(ctx context.Context) ([]model.Offer, error) {
 func (c *JujuClient) currentModelType() (string, error) {
 	modelName, err := c.store.CurrentModel(c.controllerName)
 	if err != nil {
-		return "", fmt.Errorf("resolving current model: %w", err)
+		return "", fmt.Errorf("resolving current model: %w", fmt.Errorf("%s: %w", err.Error(), ErrNoSelectedModel))
 	}
 	details, err := c.store.ModelByName(c.controllerName, modelName)
 	if err != nil {

--- a/internal/app/statusstream.go
+++ b/internal/app/statusstream.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -321,13 +322,12 @@ func (m Model) fetchOffers() tea.Cmd {
 }
 
 // isNoModelError checks whether the error indicates that no Juju model is
-// currently selected. This centralises the (fragile) string-based detection
-// so it can be tested and updated in a single place.
+// currently selected. It uses errors.Is to check for the sentinel
+// api.ErrNoSelectedModel, which is wrapped by the API layer when the
+// client store reports a missing model selection.
 func isNoModelError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "No selected model") ||
-		strings.Contains(msg, "resolving current model")
+	return errors.Is(err, api.ErrNoSelectedModel)
 }

--- a/internal/app/statusstream_test.go
+++ b/internal/app/statusstream_test.go
@@ -81,9 +81,9 @@ func TestIsNoModelError(t *testing.T) {
 	}{
 		{"nil error", nil, false},
 		{"unrelated error", fmt.Errorf("connection refused"), false},
-		{"no selected model", fmt.Errorf("No selected model"), true},
-		{"resolving current model", fmt.Errorf("error resolving current model"), true},
-		{"wrapped no selected model", fmt.Errorf("status: %w", fmt.Errorf("No selected model")), true},
+		{"sentinel directly", api.ErrNoSelectedModel, true},
+		{"wrapped sentinel", fmt.Errorf("resolving current model for controller %q: %w", "prod", fmt.Errorf("current model not set: %w", api.ErrNoSelectedModel)), true},
+		{"double wrapped sentinel", fmt.Errorf("status: %w", fmt.Errorf("inner: %w", api.ErrNoSelectedModel)), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Replace the fragile `strings.Contains()` error matching in `isNoModelError()` with proper `errors.Is()` checks against a new sentinel error.

## Changes

- **`internal/api/client.go`**: Define `ErrNoSelectedModel` sentinel error
- **`internal/api/juju.go`**: Wrap upstream `CurrentModel()` errors with the sentinel in both `connect()` and `currentModelType()`
- **`internal/app/statusstream.go`**: Replace `strings.Contains()` with `errors.Is(err, api.ErrNoSelectedModel)`
- **`internal/app/statusstream_test.go`**: Update test cases to use sentinel errors

## Why

If the upstream Juju library changes the error message wording (e.g. "No selected model" → "model not selected"), the old string matching would break silently. Using a sentinel error makes detection stable and idiomatic.

Fixes #33