### PR TITLE
feat(view): add offers view for cross-model relations

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -38,6 +38,8 @@ type Client interface {
 	CharmhubSuggestions(ctx context.Context, query string, limit int) ([]string, error)
 	// CharmRelationInfo returns endpoint metadata for a charm from Charmhub.
 	CharmRelationInfo(ctx context.Context, charmName string) (map[string]model.CharmEndpoint, error)
+	// ListOffers returns application offers for the current model.
+	ListOffers(ctx context.Context) ([]model.Offer, error)
 	// ListSecrets returns the secrets for the current model.
 	ListSecrets(ctx context.Context) ([]model.Secret, error)
 	// RevealSecret returns the decoded key-value content of a secret.

--- a/internal/api/juju.go
+++ b/internal/api/juju.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/client/application"
+	"github.com/juju/juju/api/client/applicationoffers"
 	"github.com/juju/juju/api/client/client"
 	jujuSecrets "github.com/juju/juju/api/client/secrets"
 	"github.com/juju/juju/api/common"
@@ -22,6 +23,7 @@ import (
 	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/constraints"
 	corelogger "github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/relation"
 	coreSecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/loggo/v2"
@@ -802,6 +804,42 @@ func (c *JujuClient) RevealSecret(ctx context.Context, uri string, revision int)
 		return nil, fmt.Errorf("secret %q has no value", uri)
 	}
 	return details[0].Value.Values()
+}
+
+func (c *JujuClient) ListOffers(ctx context.Context) ([]model.Offer, error) {
+	conn, err := c.connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	offersClient := applicationoffers.NewClient(conn)
+	details, err := offersClient.ListOffers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing offers: %w", err)
+	}
+
+	result := make([]model.Offer, 0, len(details))
+	for _, d := range details {
+		o := model.Offer{
+			Name:            d.OfferName,
+			ApplicationName: d.ApplicationName,
+			OfferURL:        d.OfferURL,
+			CharmURL:        d.CharmURL,
+			TotalConnCount:  len(d.Connections),
+		}
+		for _, ep := range d.Endpoints {
+			o.Endpoints = append(o.Endpoints, ep.Name)
+		}
+		for _, conn := range d.Connections {
+			if conn.Status == relation.Joined {
+				o.ActiveConnCount++
+			}
+		}
+		result = append(result, o)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result, nil
 }
 
 // currentModelType returns the model type ("iaas" or "caas") for the

--- a/internal/api/mock.go
+++ b/internal/api/mock.go
@@ -140,6 +140,16 @@ func (c *MockClient) ListSecrets(_ context.Context) ([]model.Secret, error) {
 	return s.Secrets, nil
 }
 
+// ListOffers returns synthetic application offers.
+func (c *MockClient) ListOffers(_ context.Context) ([]model.Offer, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return []model.Offer{
+		{Name: "postgresql-db", ApplicationName: "postgresql", OfferURL: "admin/mymodel.postgresql-db", Endpoints: []string{"db"}, ActiveConnCount: 2, TotalConnCount: 3},
+		{Name: "grafana-dashboard", ApplicationName: "grafana", OfferURL: "admin/mymodel.grafana-dashboard", Endpoints: []string{"grafana-dashboard"}, ActiveConnCount: 1, TotalConnCount: 1},
+	}, nil
+}
+
 // RevealSecret returns synthetic decoded content for a mock secret.
 func (c *MockClient) RevealSecret(_ context.Context, uri string, _ int) (map[string]string, error) {
 	c.mu.Lock()

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bschimke95/jara/internal/view/machines"
 	"github.com/bschimke95/jara/internal/view/models"
 	"github.com/bschimke95/jara/internal/view/modelview"
+	"github.com/bschimke95/jara/internal/view/offers"
 	"github.com/bschimke95/jara/internal/view/relations"
 	"github.com/bschimke95/jara/internal/view/secretdetail"
 	"github.com/bschimke95/jara/internal/view/secrets"
@@ -144,6 +145,7 @@ func New(client api.Client, opts ...Option) Model {
 	m.views[nav.RelationsView] = relations.New(keys, s)
 	m.views[nav.SecretsView] = secrets.New(keys, s)
 	m.views[nav.SecretDetailView] = secretdetail.New(keys, s)
+	m.views[nav.OffersView] = offers.New(keys, s)
 	m.views[nav.DebugLogView] = debuglog.New(keys, s)
 	m.views[nav.ControllerView] = controllers.New(keys, s, func() tea.Cmd { return m.pollControllers() })
 	m.views[nav.ModelsView] = models.New(keys, s,
@@ -381,6 +383,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case relations.FetchRelationDataMsg:
 		return m, m.fetchRelationData(msg.RelationID)
 
+	case offers.FetchOffersMsg:
+		return m, m.fetchOffers()
+
 	case debuglog.FilterChangedMsg:
 		return m, m.startDebugLogStream(msg.Filter)
 	}
@@ -445,6 +450,8 @@ func (m Model) viewName() string {
 		return "Secrets"
 	case nav.SecretDetailView:
 		return "Secret"
+	case nav.OffersView:
+		return "Offers"
 	case nav.DebugLogView:
 		return "Debug Log"
 	case nav.ChatView:

--- a/internal/app/input.go
+++ b/internal/app/input.go
@@ -242,6 +242,9 @@ func (m Model) handleGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 	case key.Matches(msg, m.keys.MachinesNav):
 		m2, cmd := m.handleNavigate(view.NavigateMsg{Target: nav.MachinesView})
 		return m2, cmd, true
+	case key.Matches(msg, m.keys.OffersNav):
+		m2, cmd := m.handleNavigate(view.NavigateMsg{Target: nav.OffersView})
+		return m2, cmd, true
 	case key.Matches(msg, m.keys.ChatNav):
 		m2, cmd := m.handleNavigate(view.NavigateMsg{Target: nav.ChatView})
 		return m2, cmd, true

--- a/internal/app/statusstream.go
+++ b/internal/app/statusstream.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bschimke95/jara/internal/view/controllers"
 	"github.com/bschimke95/jara/internal/view/models"
 	"github.com/bschimke95/jara/internal/view/modelview"
+	"github.com/bschimke95/jara/internal/view/offers"
 	"github.com/bschimke95/jara/internal/view/relations"
 )
 
@@ -302,6 +303,20 @@ func (m Model) fetchRelationData(relationID int) tea.Cmd {
 			return errMsg{err}
 		}
 		return relations.RelationDataMsg{RelationID: relationID, Data: data}
+	}
+}
+
+// fetchOffers returns a Cmd that fetches application offers from the API.
+func (m Model) fetchOffers() tea.Cmd {
+	client := m.client
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		offerList, err := client.ListOffers(ctx)
+		if err != nil {
+			return errMsg{fmt.Errorf("fetching offers: %w", err)}
+		}
+		return offers.OffersDataMsg{Offers: offerList}
 	}
 }
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -212,6 +212,17 @@ type RelationData struct {
 	UnitData map[string]map[string]string
 }
 
+// Offer represents a Juju application offer (cross-model relation endpoint).
+type Offer struct {
+	Name            string
+	ApplicationName string
+	OfferURL        string
+	CharmURL        string
+	Endpoints       []string // endpoint names
+	ActiveConnCount int
+	TotalConnCount  int
+}
+
 // CharmEndpoint describes a single endpoint from a charm's metadata.
 type CharmEndpoint struct {
 	Interface   string

--- a/internal/nav/nav.go
+++ b/internal/nav/nav.go
@@ -19,6 +19,7 @@ const (
 	ModelsView
 	SecretsView
 	SecretDetailView
+	OffersView
 	ChatView
 )
 
@@ -45,6 +46,8 @@ func (v ViewID) String() string {
 		return "Secrets"
 	case SecretDetailView:
 		return "Secret"
+	case OffersView:
+		return "Offers"
 	case ChatView:
 		return "Chat"
 	default:
@@ -79,6 +82,9 @@ var CommandAliases = map[string]ViewID{
 	"secrets":      SecretsView,
 	"secret":       SecretsView,
 	"sec":          SecretsView,
+	"offers":       OffersView,
+	"offer":        OffersView,
+	"off":          OffersView,
 	"chat":         ChatView,
 	"ai":           ChatView,
 	"analyze":      ChatView,

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -37,6 +37,7 @@ type KeyMap struct {
 	RelationsNav    key.Binding // Shift+R: navigate to relations view
 	SecretsNav      key.Binding // Shift+S: navigate to secrets view
 	MachinesNav     key.Binding // Shift+M: navigate to machines view
+	OffersNav       key.Binding // O: navigate to offers view
 	Decode          key.Binding // d: decode/reveal secret content
 	ApplyFilter     key.Binding // Shift+F: apply filter in modal
 	Right           key.Binding // l/right: move right in modal
@@ -170,6 +171,10 @@ func DefaultKeyMap() KeyMap {
 		MachinesNav: key.NewBinding(
 			key.WithKeys("M"),
 			key.WithHelp("M", "machines"),
+		),
+		OffersNav: key.NewBinding(
+			key.WithKeys("O"),
+			key.WithHelp("O", "offers"),
 		),
 		Decode: key.NewBinding(
 			key.WithKeys("d"),

--- a/internal/view/offers/rows.go
+++ b/internal/view/offers/rows.go
@@ -1,0 +1,37 @@
+package offers
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/table"
+
+	"github.com/bschimke95/jara/internal/model"
+)
+
+// Columns defines the columns for the offers table.
+func Columns() []table.Column {
+	return []table.Column{
+		{Title: "Offer", Width: 22},
+		{Title: "Application", Width: 18},
+		{Title: "URL", Width: 36},
+		{Title: "Endpoints", Width: 20},
+		{Title: "Connections", Width: 14},
+	}
+}
+
+// Rows converts a slice of offers to table rows.
+func Rows(offers []model.Offer) []table.Row {
+	rows := make([]table.Row, 0, len(offers))
+	for _, o := range offers {
+		conns := fmt.Sprintf("%d/%d", o.ActiveConnCount, o.TotalConnCount)
+		rows = append(rows, table.Row{
+			o.Name,
+			o.ApplicationName,
+			o.OfferURL,
+			strings.Join(o.Endpoints, ", "),
+			conns,
+		})
+	}
+	return rows
+}

--- a/internal/view/offers/types.go
+++ b/internal/view/offers/types.go
@@ -1,0 +1,27 @@
+package offers
+
+import (
+	"charm.land/bubbles/v2/table"
+
+	"github.com/bschimke95/jara/internal/color"
+	"github.com/bschimke95/jara/internal/model"
+	"github.com/bschimke95/jara/internal/ui"
+)
+
+// FetchOffersMsg signals the app to fetch offers from the API.
+type FetchOffersMsg struct{}
+
+// OffersDataMsg carries the fetched offers data back to the view.
+type OffersDataMsg struct {
+	Offers []model.Offer
+	Err    error
+}
+
+// View is the Bubble Tea model for the offers table view.
+type View struct {
+	table  table.Model
+	keys   ui.KeyMap
+	styles *color.Styles
+	width  int
+	height int
+}

--- a/internal/view/offers/view.go
+++ b/internal/view/offers/view.go
@@ -1,0 +1,61 @@
+// Package offers implements the self-contained offers table view.
+package offers
+
+import (
+	"charm.land/bubbles/v2/table"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/bschimke95/jara/internal/color"
+	"github.com/bschimke95/jara/internal/ui"
+	"github.com/bschimke95/jara/internal/view"
+)
+
+// New creates a new offers view.
+func New(keys ui.KeyMap, styles *color.Styles) *View {
+	cols := Columns()
+	t := table.New(
+		table.WithColumns(cols),
+		table.WithFocused(true),
+		table.WithHeight(10),
+	)
+	t.SetStyles(ui.StyledTable(styles))
+	return &View{table: t, keys: keys, styles: styles}
+}
+
+func (v *View) SetSize(width, height int) {
+	v.width = width
+	v.height = height
+	v.table.SetWidth(width)
+	v.table.SetHeight(height)
+	v.table.SetColumns(ui.ScaleColumns(Columns(), width))
+}
+
+// KeyHints returns the view-specific key hints for the header.
+func (v *View) KeyHints() []view.KeyHint {
+	return nil
+}
+
+func (v *View) Init() tea.Cmd { return nil }
+
+func (v *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if dataMsg, ok := msg.(OffersDataMsg); ok {
+		if dataMsg.Err == nil {
+			v.table.SetRows(Rows(dataMsg.Offers))
+		}
+		return v, nil
+	}
+
+	var cmd tea.Cmd
+	v.table, cmd = v.table.Update(msg)
+	return v, cmd
+}
+
+func (v *View) View() tea.View {
+	return tea.NewView(v.table.View())
+}
+
+func (v *View) Enter(_ view.NavigateContext) (tea.Cmd, error) {
+	return func() tea.Msg { return FetchOffersMsg{} }, nil
+}
+
+func (v *View) Leave() tea.Cmd { return nil }


### PR DESCRIPTION
## Summary

Add a new Offers view for browsing Juju application offers (cross-model relation endpoints).

### How it works
- Press **O** (Shift+O) from any view to navigate to the offers view
- Or use `:offers` / `:offer` / `:off` commands
- Shows a table with columns: **Offer**, **Application**, **URL**, **Endpoints**, **Connections** (active/total)

### Changes
- **Model**: Add `Offer` type with fields for name, application, URL, charm, endpoints, and connection counts
- **API**: Add `ListOffers()` method to `Client` interface, implemented in `JujuClient` using the `applicationoffers` facade's `ListOffers()` method with `crossmodel` filter
- **Mock**: Add mock returning 2 synthetic offers (postgresql-db, grafana-dashboard)
- **View**: New `internal/view/offers` package following the standard 3-file pattern (types.go, view.go, rows.go)
- **Navigation**: Add `OffersView` to nav stack with `:offers`, `:offer`, `:off` aliases
- **Keys**: Add `OffersNav` binding (Shift+O) with global key handler
- **Wiring**: Fetch offers via `statusstream.go`, dispatch in `app.go`

Closes #24