### PR TITLE
fix(chat): prevent chat view from swallowing global key bindings

### DIFF
--- a/internal/view/chat/view.go
+++ b/internal/view/chat/view.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
@@ -116,14 +117,34 @@ func (v *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return v, nil
 	}
 
+	// When no AI provider is configured the view is a static info screen.
+	// Only handle Back (Esc) to navigate away; let everything else bubble
+	// up to global handlers.
+	if v.llmClient == nil {
+		if key.Matches(kp, v.keys.Back) {
+			return v, func() tea.Msg { return view.GoBackMsg{} }
+		}
+		return v, nil
+	}
+
 	// Handle key presses based on mode.
+	switch v.mode {
+	case modeInput:
+		return v.updateInputMode(kp)
+	case modeScroll:
+		return v.updateScrollMode(kp)
+	}
+
+	return v, nil
+}
+
+// updateInputMode handles keys when the user is typing in the input prompt.
+// All printable characters (including j, k, g, :, /, etc.) are captured as
+// text input. Only non-text keys (arrows, ctrl sequences) are used for
+// scrolling so they don't conflict with typing.
+func (v *View) updateInputMode(kp tea.KeyPressMsg) (*View, tea.Cmd) {
 	switch {
 	case key.Matches(kp, v.keys.Back):
-		if v.mode == modeScroll {
-			v.mode = modeInput
-			v.scrollOffset = 0
-			return v, noopCmd
-		}
 		// In input mode with empty buffer, navigate back.
 		if v.inputBuf == "" {
 			return v, func() tea.Msg { return view.GoBackMsg{} }
@@ -137,31 +158,33 @@ func (v *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case kp.String() == "backspace":
 		if len(v.inputBuf) > 0 {
-			v.inputBuf = v.inputBuf[:len(v.inputBuf)-1]
+			_, size := utf8.DecodeLastRuneInString(v.inputBuf)
+			v.inputBuf = v.inputBuf[:len(v.inputBuf)-size]
 		}
 		return v, noopCmd
 
-	case key.Matches(kp, v.keys.Up):
+	// Allow scrolling with arrow/page keys that don't conflict with text input.
+	// Notably, we match by key string rather than key binding here to avoid
+	// capturing "k"/"j"/"g"/"G" which the user needs to type as text.
+	case kp.String() == "up":
 		return v.handleScroll(1)
 
-	case key.Matches(kp, v.keys.Down):
+	case kp.String() == "down":
 		return v.handleScroll(-1)
 
 	case key.Matches(kp, v.keys.PageUp):
-		return v.handleScroll(v.messageAreaHeight() / 2)
+		delta := v.messageAreaHeight() / 2
+		if delta < 1 {
+			delta = 1
+		}
+		return v.handleScroll(delta)
 
 	case key.Matches(kp, v.keys.PageDown):
-		return v.handleScroll(-v.messageAreaHeight() / 2)
-
-	case key.Matches(kp, v.keys.Top):
-		v.scrollOffset = v.maxScroll()
-		v.mode = modeScroll
-		return v, noopCmd
-
-	case key.Matches(kp, v.keys.Bottom):
-		v.scrollOffset = 0
-		v.mode = modeInput
-		return v, noopCmd
+		delta := v.messageAreaHeight() / 2
+		if delta < 1 {
+			delta = 1
+		}
+		return v.handleScroll(-delta)
 
 	default:
 		// Append printable characters to input buffer.
@@ -171,6 +194,52 @@ func (v *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	return v, nil
+}
+
+// updateScrollMode handles keys when the user is scrolling through messages.
+// Only scroll-related keys are consumed; everything else returns nil so that
+// global key handlers can process them (e.g. ":" for command mode, "q" for
+// quit, "?" for help).
+func (v *View) updateScrollMode(kp tea.KeyPressMsg) (*View, tea.Cmd) {
+	switch {
+	case key.Matches(kp, v.keys.Back):
+		v.mode = modeInput
+		v.scrollOffset = 0
+		return v, noopCmd
+
+	case key.Matches(kp, v.keys.Up):
+		return v.handleScroll(1)
+
+	case key.Matches(kp, v.keys.Down):
+		return v.handleScroll(-1)
+
+	case key.Matches(kp, v.keys.PageUp):
+		delta := v.messageAreaHeight() / 2
+		if delta < 1 {
+			delta = 1
+		}
+		return v.handleScroll(delta)
+
+	case key.Matches(kp, v.keys.PageDown):
+		delta := v.messageAreaHeight() / 2
+		if delta < 1 {
+			delta = 1
+		}
+		return v.handleScroll(-delta)
+
+	case key.Matches(kp, v.keys.Top):
+		v.scrollOffset = v.maxScroll()
+		return v, noopCmd
+
+	case key.Matches(kp, v.keys.Bottom):
+		v.scrollOffset = 0
+		v.mode = modeInput
+		return v, noopCmd
+	}
+
+	// In scroll mode, don't consume unhandled keys — let them bubble up
+	// to global handlers (e.g. ':' for command mode, 'q' for quit).
 	return v, nil
 }
 

--- a/internal/view/chat/view_test.go
+++ b/internal/view/chat/view_test.go
@@ -225,6 +225,272 @@ func TestView_OutputExactHeight(t *testing.T) {
 	}
 }
 
+// newNoClientView creates a chat view with no AI provider (llmClient == nil).
+func newNoClientView() *View {
+	keys := ui.DefaultKeyMap()
+	styles := color.DefaultStyles()
+	v := New(keys, styles, nil, llm.DefaultSystemPrompt, "")
+	v.SetSize(80, 24)
+	return v
+}
+
+// --- Tests for modeInput key handling ---
+
+func TestInputMode_LetterKeysTypeText(t *testing.T) {
+	// Keys like j, k, g, G should be typed as text in modeInput,
+	// not trigger scrolling (which uses the same key bindings globally).
+	v := newTestView()
+
+	letters := []struct {
+		code rune
+		text string
+	}{
+		{'j', "j"},
+		{'k', "k"},
+		{'g', "g"},
+		{'G', "G"},
+		{':', ":"},
+		{'/', "/"},
+		{'q', "q"},
+		{'?', "?"},
+	}
+
+	for _, l := range letters {
+		v.inputBuf = ""
+		updated, cmd := v.Update(tea.KeyPressMsg{Code: l.code, Text: l.text})
+		v = updated.(*View)
+		if v.inputBuf != l.text {
+			t.Errorf("pressing %q: expected inputBuf=%q, got %q", l.text, l.text, v.inputBuf)
+		}
+		if cmd == nil {
+			t.Errorf("pressing %q: expected non-nil cmd (key consumed by view)", l.text)
+		}
+	}
+}
+
+func TestInputMode_ArrowKeysScroll(t *testing.T) {
+	// Arrow keys (not j/k) should still scroll in modeInput.
+	v := newTestView()
+	// Add messages so there is something to scroll.
+	v.messages = make([]chatMessage, 50)
+	for i := range v.messages {
+		v.messages[i] = chatMessage{Role: llm.RoleUser, Content: "line", Timestamp: time.Now()}
+	}
+
+	updated, cmd := v.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	v = updated.(*View)
+	if v.scrollOffset == 0 {
+		t.Error("up arrow should scroll in modeInput")
+	}
+	if cmd == nil {
+		t.Error("up arrow should return non-nil cmd (consumed)")
+	}
+
+	prev := v.scrollOffset
+	updated, _ = v.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	v = updated.(*View)
+	if v.scrollOffset >= prev {
+		t.Error("down arrow should scroll down in modeInput")
+	}
+}
+
+func TestInputMode_EscGoesBack(t *testing.T) {
+	// With an empty input buffer, Esc should emit GoBackMsg.
+	v := newTestView()
+	v.inputBuf = ""
+
+	_, cmd := v.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for Esc with empty buffer")
+	}
+	msg := cmd()
+	if _, ok := msg.(view.GoBackMsg); !ok {
+		t.Fatalf("expected GoBackMsg, got %T", msg)
+	}
+}
+
+func TestInputMode_EscClearsBuffer(t *testing.T) {
+	// With text in the buffer, Esc should clear it (not navigate back).
+	v := newTestView()
+	v.inputBuf = "some text"
+
+	updated, cmd := v.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	v = updated.(*View)
+	if v.inputBuf != "" {
+		t.Errorf("expected inputBuf to be cleared, got %q", v.inputBuf)
+	}
+	if cmd == nil {
+		t.Error("expected non-nil cmd (key consumed)")
+	}
+	// Should NOT produce GoBackMsg.
+	if cmd != nil {
+		msg := cmd()
+		if _, ok := msg.(view.GoBackMsg); ok {
+			t.Error("Esc with non-empty buffer should not produce GoBackMsg")
+		}
+	}
+}
+
+// --- Tests for modeScroll key handling ---
+
+func TestScrollMode_GlobalKeysBubbleUp(t *testing.T) {
+	// In modeScroll, keys like ':', '/', 'q', '?' should NOT be consumed
+	// by the chat view (cmd should be nil) so global handlers can act.
+	v := newTestView()
+	v.mode = modeScroll
+
+	globalKeys := []struct {
+		code rune
+		text string
+		desc string
+	}{
+		{':', ":", "command mode"},
+		{'/', "/", "filter mode"},
+		{'q', "q", "quit"},
+		{'?', "?", "help"},
+		{'S', "S", "secrets nav"},
+		{'M', "M", "machines nav"},
+		{'O', "O", "offers nav"},
+		{'c', "c", "chat nav"},
+	}
+
+	for _, gk := range globalKeys {
+		v.mode = modeScroll // Reset mode for each test.
+		_, cmd := v.Update(tea.KeyPressMsg{Code: gk.code, Text: gk.text})
+		if cmd != nil {
+			t.Errorf("pressing %q (%s) in modeScroll: expected nil cmd (bubble up), got non-nil", gk.text, gk.desc)
+		}
+	}
+}
+
+func TestScrollMode_DoesNotCaptureText(t *testing.T) {
+	// In modeScroll, printable characters should NOT be appended to inputBuf.
+	v := newTestView()
+	v.mode = modeScroll
+	v.inputBuf = ""
+
+	v.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	if v.inputBuf != "" {
+		t.Errorf("expected inputBuf to remain empty in modeScroll, got %q", v.inputBuf)
+	}
+}
+
+func TestScrollMode_ScrollKeysWork(t *testing.T) {
+	// Scroll-specific keys (j, k, g, G) should still work in modeScroll.
+	v := newTestView()
+	v.mode = modeScroll
+	// Add messages so there is content to scroll through.
+	v.messages = make([]chatMessage, 50)
+	for i := range v.messages {
+		v.messages[i] = chatMessage{Role: llm.RoleUser, Content: "line", Timestamp: time.Now()}
+	}
+
+	// k (up) should scroll and return non-nil cmd.
+	updated, cmd := v.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	v = updated.(*View)
+	if cmd == nil {
+		t.Error("k in modeScroll should return non-nil cmd (consumed)")
+	}
+	if v.scrollOffset == 0 {
+		t.Error("k in modeScroll should scroll up")
+	}
+
+	// j (down) should scroll down.
+	_, cmd = v.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	if cmd == nil {
+		t.Error("j in modeScroll should return non-nil cmd (consumed)")
+	}
+}
+
+func TestScrollMode_EscGoesToInput(t *testing.T) {
+	// Esc in modeScroll should return to modeInput.
+	v := newTestView()
+	v.mode = modeScroll
+	v.scrollOffset = 5
+
+	updated, cmd := v.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	v = updated.(*View)
+	if v.mode != modeInput {
+		t.Errorf("expected modeInput after Esc in modeScroll, got %d", v.mode)
+	}
+	if v.scrollOffset != 0 {
+		t.Error("scrollOffset should be reset after Esc in modeScroll")
+	}
+	if cmd == nil {
+		t.Error("Esc in modeScroll should return non-nil cmd (consumed)")
+	}
+}
+
+func TestScrollMode_GGoesToBottom(t *testing.T) {
+	// G (shift+g) in modeScroll should go to bottom and switch to modeInput.
+	v := newTestView()
+	v.mode = modeScroll
+	v.scrollOffset = 10
+
+	updated, cmd := v.Update(tea.KeyPressMsg{Code: 'G', Text: "G"})
+	v = updated.(*View)
+	if v.mode != modeInput {
+		t.Errorf("expected modeInput after G in modeScroll, got %d", v.mode)
+	}
+	if v.scrollOffset != 0 {
+		t.Error("scrollOffset should be 0 after G in modeScroll")
+	}
+	if cmd == nil {
+		t.Error("G in modeScroll should return non-nil cmd (consumed)")
+	}
+}
+
+// --- Tests for no-client mode ---
+
+func TestNoClient_EscNavigatesBack(t *testing.T) {
+	// When no AI provider is configured, Esc should emit GoBackMsg.
+	v := newNoClientView()
+
+	_, cmd := v.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for Esc with no client")
+	}
+	msg := cmd()
+	if _, ok := msg.(view.GoBackMsg); !ok {
+		t.Fatalf("expected GoBackMsg, got %T", msg)
+	}
+}
+
+func TestNoClient_GlobalKeysBubbleUp(t *testing.T) {
+	// When no AI provider is configured, all non-Esc keys should return
+	// nil cmd so global handlers can process them.
+	v := newNoClientView()
+
+	keys := []struct {
+		code rune
+		text string
+	}{
+		{':', ":"},
+		{'/', "/"},
+		{'q', "q"},
+		{'?', "?"},
+		{'j', "j"},
+		{'k', "k"},
+	}
+
+	for _, k := range keys {
+		_, cmd := v.Update(tea.KeyPressMsg{Code: k.code, Text: k.text})
+		if cmd != nil {
+			t.Errorf("pressing %q with no client: expected nil cmd (bubble up), got non-nil", k.text)
+		}
+	}
+}
+
+func TestNoClient_DoesNotCaptureText(t *testing.T) {
+	// When no AI provider is configured, text should not be captured.
+	v := newNoClientView()
+
+	v.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	if v.inputBuf != "" {
+		t.Errorf("expected inputBuf to remain empty with no client, got %q", v.inputBuf)
+	}
+}
+
 var errTest = &testError{}
 
 type testError struct{}


### PR DESCRIPTION
## Summary

- **Fix chat view trapping users** by splitting the monolithic key handler into mode-specific methods (`updateInputMode` / `updateScrollMode`), so that global keys (`:`, `/`, `q`, `?`, navigation shortcuts) bubble up to the app-level handler in scroll mode and when no AI provider is configured.
- **Fix letter keys (j/k/g/G) being intercepted as scroll commands** in input mode — they are now correctly typed as text. Arrow and page keys are used for scrolling instead.
- **Fix no-client screen swallowing all keys** — when `llmClient == nil`, only `Esc` is handled (to navigate back); everything else passes through to global handlers.

## Testing

Added 12 new tests covering all three scenarios (modeInput, modeScroll, no-client).