### PR TITLE
fix: add mutex synchronization to JujuClient to prevent data races

### DIFF
--- a/internal/api/juju.go
+++ b/internal/api/juju.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/juju/juju/api"
@@ -51,6 +52,7 @@ func (nopLogger) Helper()                                                       
 
 // JujuClient connects to a real Juju controller using the local client store.
 type JujuClient struct {
+	mu             sync.RWMutex
 	store          jujuclient.ClientStore
 	controllerName string
 	modelUUID      string
@@ -259,6 +261,8 @@ func (c *JujuClient) Close() error {
 // and persists the selection to the local Juju client store so that
 // subsequent juju CLI invocations also use the new controller.
 func (c *JujuClient) SelectController(name string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if err := c.store.SetCurrentController(name); err != nil {
 		return fmt.Errorf("persisting controller selection: %w", err)
 	}
@@ -269,12 +273,16 @@ func (c *JujuClient) SelectController(name string) error {
 
 // ControllerName returns the name of the currently targeted controller.
 func (c *JujuClient) ControllerName() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.controllerName
 }
 
 // SelectModel switches the client to target the given model (qualified name
 // "owner/name") within the current controller and persists the selection.
 func (c *JujuClient) SelectModel(qualifiedName string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if err := c.store.SetCurrentModel(c.controllerName, qualifiedName); err != nil {
 		return fmt.Errorf("persisting model selection: %w", err)
 	}
@@ -287,14 +295,18 @@ func (c *JujuClient) SelectModel(qualifiedName string) error {
 // from the client store so that the connection is model-scoped (required
 // for the "Client" facade used by Status).
 func (c *JujuClient) connect(ctx context.Context) (api.Connection, error) {
+	c.mu.RLock()
 	modelUUID := c.modelUUID
+	controllerName := c.controllerName
+	c.mu.RUnlock()
+
 	if modelUUID == "" {
 		// Resolve the current model for this controller from the client store.
-		modelName, err := c.store.CurrentModel(c.controllerName)
+		modelName, err := c.store.CurrentModel(controllerName)
 		if err != nil {
-			return nil, fmt.Errorf("resolving current model for controller %q: %w", c.controllerName, fmt.Errorf("%s: %w", err.Error(), ErrNoSelectedModel))
+			return nil, fmt.Errorf("resolving current model for controller %q: %w: %w", controllerName, err, ErrNoSelectedModel)
 		}
-		modelDetails, err := c.store.ModelByName(c.controllerName, modelName)
+		modelDetails, err := c.store.ModelByName(controllerName, modelName)
 		if err != nil {
 			return nil, fmt.Errorf("getting model details for %q: %w", modelName, err)
 		}
@@ -302,7 +314,7 @@ func (c *JujuClient) connect(ctx context.Context) (api.Connection, error) {
 	}
 
 	cfg := connector.ClientStoreConfig{
-		ControllerName: c.controllerName,
+		ControllerName: controllerName,
 		ModelUUID:      modelUUID,
 		ClientStore:    c.store,
 	}
@@ -314,7 +326,7 @@ func (c *JujuClient) connect(ctx context.Context) (api.Connection, error) {
 
 	conn, err := cs.Connect(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("connecting to controller %q: %w", c.controllerName, err)
+		return nil, fmt.Errorf("connecting to controller %q: %w", controllerName, err)
 	}
 
 	return conn, nil
@@ -1024,11 +1036,15 @@ func (c *JujuClient) ListStorage(ctx context.Context) ([]model.StorageInstance, 
 // currentModelType returns the model type ("iaas" or "caas") for the
 // currently targeted model by reading from the local client store.
 func (c *JujuClient) currentModelType() (string, error) {
-	modelName, err := c.store.CurrentModel(c.controllerName)
+	c.mu.RLock()
+	controllerName := c.controllerName
+	c.mu.RUnlock()
+
+	modelName, err := c.store.CurrentModel(controllerName)
 	if err != nil {
-		return "", fmt.Errorf("resolving current model: %w", fmt.Errorf("%s: %w", err.Error(), ErrNoSelectedModel))
+		return "", fmt.Errorf("resolving current model: %w: %w", err, ErrNoSelectedModel)
 	}
-	details, err := c.store.ModelByName(c.controllerName, modelName)
+	details, err := c.store.ModelByName(controllerName, modelName)
 	if err != nil {
 		return "", fmt.Errorf("getting model details: %w", err)
 	}

--- a/internal/app/statusstream.go
+++ b/internal/app/statusstream.go
@@ -216,13 +216,15 @@ func (m Model) revealSecret(uri string, revision int) tea.Cmd {
 
 // scaleApplication returns a Cmd that calls ScaleApplication on the API client.
 func (m Model) scaleApplication(appName string, delta int) tea.Cmd {
+	client := m.client
+	cfg := m.cfg
 	return func() tea.Msg {
-		if m.cfg != nil && m.cfg.Jara.ReadOnly {
+		if cfg != nil && cfg.Jara.ReadOnly {
 			return errMsg{fmt.Errorf("write operations are disabled in read-only mode")}
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
-		if err := m.client.ScaleApplication(ctx, appName, delta); err != nil {
+		if err := client.ScaleApplication(ctx, appName, delta); err != nil {
 			return errMsg{err}
 		}
 		return nil
@@ -232,15 +234,17 @@ func (m Model) scaleApplication(appName string, delta int) tea.Cmd {
 // deployApplication returns a Cmd that deploys a new application charm.
 // If modelName is set, deployment is targeted to that model first.
 func (m Model) deployApplication(modelName string, opts model.DeployOptions) tea.Cmd {
+	client := m.client
+	cfg := m.cfg
+	current := m.stack.Current()
 	return func() tea.Msg {
-		if m.cfg != nil && m.cfg.Jara.ReadOnly {
+		if cfg != nil && cfg.Jara.ReadOnly {
 			return errMsg{fmt.Errorf("write operations are disabled in read-only mode")}
 		}
 		if strings.TrimSpace(opts.CharmName) == "" {
 			return errMsg{fmt.Errorf("charm name is required")}
 		}
 		if modelName == "" {
-			current := m.stack.Current()
 			if current.View == nav.ModelView && current.Context != "" {
 				modelName = current.Context
 			}
@@ -248,11 +252,11 @@ func (m Model) deployApplication(modelName string, opts model.DeployOptions) tea
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		if modelName != "" {
-			if err := m.client.SelectModel(modelName); err != nil {
+			if err := client.SelectModel(modelName); err != nil {
 				return errMsg{fmt.Errorf("selecting model %q: %w", modelName, err)}
 			}
 		}
-		if err := m.client.DeployApplication(ctx, opts); err != nil {
+		if err := client.DeployApplication(ctx, opts); err != nil {
 			return errMsg{err}
 		}
 		return nil
@@ -261,8 +265,10 @@ func (m Model) deployApplication(modelName string, opts model.DeployOptions) tea
 
 // relateApplications returns a Cmd that creates a relation between two endpoints.
 func (m Model) relateApplications(endpointA, endpointB string) tea.Cmd {
+	client := m.client
+	cfg := m.cfg
 	return func() tea.Msg {
-		if m.cfg != nil && m.cfg.Jara.ReadOnly {
+		if cfg != nil && cfg.Jara.ReadOnly {
 			return errMsg{fmt.Errorf("write operations are disabled in read-only mode")}
 		}
 		if strings.TrimSpace(endpointA) == "" || strings.TrimSpace(endpointB) == "" {
@@ -270,7 +276,7 @@ func (m Model) relateApplications(endpointA, endpointB string) tea.Cmd {
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		if err := m.client.RelateApplications(ctx, endpointA, endpointB); err != nil {
+		if err := client.RelateApplications(ctx, endpointA, endpointB); err != nil {
 			return errMsg{err}
 		}
 		return nil
@@ -279,8 +285,10 @@ func (m Model) relateApplications(endpointA, endpointB string) tea.Cmd {
 
 // destroyRelation returns a Cmd that removes a relation between two endpoints.
 func (m Model) destroyRelation(endpointA, endpointB string) tea.Cmd {
+	client := m.client
+	cfg := m.cfg
 	return func() tea.Msg {
-		if m.cfg != nil && m.cfg.Jara.ReadOnly {
+		if cfg != nil && cfg.Jara.ReadOnly {
 			return errMsg{fmt.Errorf("write operations are disabled in read-only mode")}
 		}
 		if strings.TrimSpace(endpointA) == "" || strings.TrimSpace(endpointB) == "" {
@@ -288,7 +296,7 @@ func (m Model) destroyRelation(endpointA, endpointB string) tea.Cmd {
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		if err := m.client.DestroyRelation(ctx, endpointA, endpointB); err != nil {
+		if err := client.DestroyRelation(ctx, endpointA, endpointB); err != nil {
 			return errMsg{err}
 		}
 		return nil

--- a/internal/app/statusstream_test.go
+++ b/internal/app/statusstream_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bschimke95/jara/internal/api"
 	"github.com/bschimke95/jara/internal/config"
 	"github.com/bschimke95/jara/internal/model"
+	"github.com/bschimke95/jara/internal/nav"
 	"github.com/bschimke95/jara/internal/ui"
 )
 
@@ -20,6 +21,7 @@ func TestDeployApplicationReadOnly(t *testing.T) {
 	m := Model{
 		client: api.NewMockClient(),
 		cfg:    cfg,
+		stack:  nav.NewStack(nav.ModelView),
 	}
 
 	msg := m.deployApplication("", model.DeployOptions{CharmName: "redis-k8s", ApplicationName: "redis"})()
@@ -57,6 +59,7 @@ func TestDeployApplicationTargetsModel(t *testing.T) {
 	m := Model{
 		client: client,
 		cfg:    config.NewDefault(),
+		stack:  nav.NewStack(nav.ModelView),
 	}
 
 	msg := m.deployApplication("admin/default", model.DeployOptions{CharmName: "redis-k8s", ApplicationName: "redis"})()


### PR DESCRIPTION
## Summary
- Add `sync.RWMutex` to `JujuClient` to protect concurrent access to `controllerName` and `modelUUID` fields
- Fix closure captures in `statusstream.go` to capture `m.client`, `m.cfg`, and `m.stack.Current()` before returning closures
- Fix double-wrapped error pattern to use Go 1.20+ multiple `%w` syntax

Fixes #44