### PR TITLE
fix: cancel streams and close API client on quit

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -185,8 +185,13 @@ func New(client api.Client, opts ...Option) Model {
 
 // quit closes any open resources and returns tea.Quit.
 func (m Model) quit() (Model, tea.Cmd) {
+	m.stopStatusStream()
+	m.stopDebugLogStream()
 	if m.llmClient != nil {
 		_ = m.llmClient.Close()
+	}
+	if m.client != nil {
+		_ = m.client.Close()
 	}
 	return m, tea.Quit
 }


### PR DESCRIPTION
## Summary
- Cancel status and debug-log stream goroutines in `quit()` before exiting
- Close the API client to clean up any open connections

Fixes #46