### PR TITLE
fix: add nil/bounds guards to prevent panics in navigation and API

### DIFF
--- a/internal/api/juju.go
+++ b/internal/api/juju.go
@@ -936,6 +936,9 @@ func (c *JujuClient) RunAction(ctx context.Context, unitName, actionName string,
 	if len(enqueued.Actions) == 0 {
 		return nil, fmt.Errorf("no actions enqueued")
 	}
+	if enqueued.Actions[0].Action == nil {
+		return nil, fmt.Errorf("enqueued action has no action details")
+	}
 
 	actionID := enqueued.Actions[0].Action.ID
 

--- a/internal/app/navigate.go
+++ b/internal/app/navigate.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"fmt"
+
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/bschimke95/jara/internal/nav"
@@ -9,6 +11,10 @@ import (
 
 func (m Model) handleNavigate(msg view.NavigateMsg) (Model, tea.Cmd) {
 	target := m.views[msg.Target]
+	if target == nil {
+		m.err = fmt.Errorf("unknown view: %v", msg.Target)
+		return m, nil
+	}
 
 	// Snapshot the stack before mutating so we can roll back if Enter fails.
 	snap := m.stack.Snapshot()

--- a/internal/nav/nav.go
+++ b/internal/nav/nav.go
@@ -177,7 +177,11 @@ func (s *Stack) Pop() (StackEntry, bool) {
 }
 
 // Current returns the current (top) entry.
+// Panics if the stack is empty (which should never happen when using NewStack).
 func (s *Stack) Current() StackEntry {
+	if len(s.entries) == 0 {
+		panic("nav.Stack.Current called on empty stack; use NewStack to create stacks")
+	}
 	return s.entries[len(s.entries)-1]
 }
 
@@ -213,7 +217,11 @@ func (s *Stack) Snapshot() []StackEntry {
 }
 
 // Restore replaces the stack entries with a previously-taken snapshot.
+// Panics if snap is empty, as the stack must always have at least one entry.
 func (s *Stack) Restore(snap []StackEntry) {
+	if len(snap) == 0 {
+		panic("nav.Stack.Restore called with empty snapshot")
+	}
 	s.entries = make([]StackEntry, len(snap))
 	copy(s.entries, snap)
 }


### PR DESCRIPTION
## Summary
- Add nil check for unregistered view IDs in `handleNavigate` to prevent panic on unknown views
- Add nil check for `enqueued.Actions[0].Action` in `RunAction` 
- Add panic guards with clear messages in `Stack.Current()` and `Stack.Restore()` for empty stacks

Fixes #48