### PR TITLE
fix: store revealModal update result instead of discarding it

### DIFF
--- a/internal/view/secretdetail/view.go
+++ b/internal/view/secretdetail/view.go
@@ -75,7 +75,10 @@ func (v *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			v.revealOpen = false
 			return v, nil
 		}
-		_, cmd := v.revealModal.Update(msg)
+		updated, cmd := v.revealModal.Update(msg)
+		if m, ok := updated.(*revealmodal.Modal); ok {
+			v.revealModal = *m
+		}
 		return v, cmd
 	}
 


### PR DESCRIPTION
## Summary
- Store the `tea.Model` returned by `revealModal.Update(msg)` back into `v.revealModal` instead of discarding it with `_`
- This follows the Bubble Tea contract where `Update` may return a new/modified model
- Without this fix, any state changes that rely on the returned model (rather than pointer-receiver mutation) would be silently lost

Fixes #49