### PR TITLE
fix: prevent last user message from appearing in both history and prompt

### DIFF
--- a/internal/llm/copilot.go
+++ b/internal/llm/copilot.go
@@ -106,14 +106,25 @@ func (c *CopilotClient) ChatStream(ctx context.Context, messages []Message) (<-c
 	var systemPrompt string
 	var lastUserMsg string
 	var history []Message
+
+	// Find the index of the last user message so we can exclude it
+	// from history and use it as the prompt.
+	lastUserIdx := -1
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == RoleUser {
+			lastUserIdx = i
+			break
+		}
+	}
+
 	for i, m := range messages {
 		switch m.Role {
 		case RoleSystem:
 			systemPrompt = m.Content
 		case RoleUser:
-			lastUserMsg = m.Content
-			// All but the last user message are history.
-			if i < len(messages)-1 {
+			if i == lastUserIdx {
+				lastUserMsg = m.Content
+			} else {
 				history = append(history, m)
 			}
 		case RoleAssistant:


### PR DESCRIPTION
## Summary
- Fixed duplicate message bug in Copilot chat where the last user message could appear in both the conversation history and the prompt
- The old logic used `i < len(messages)-1` to decide if a user message was the "last" one, which failed when the final message in the slice was an assistant message
- Now scans backwards to find the actual last user message index and uses that for correct partitioning

Fixes #51