### PR TITLE
fix: add missing key binding config fields for OffersNav, StorageNav, RunAction, ConfigNav

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -224,11 +224,15 @@ type KeysConfig struct {
 	RelationsNav    *KeyBindingConfig `yaml:"relationsNav,omitempty"`
 	SecretsNav      *KeyBindingConfig `yaml:"secretsNav,omitempty"`
 	MachinesNav     *KeyBindingConfig `yaml:"machinesNav,omitempty"`
+	OffersNav       *KeyBindingConfig `yaml:"offersNav,omitempty"`
+	StorageNav      *KeyBindingConfig `yaml:"storageNav,omitempty"`
 	Decode          *KeyBindingConfig `yaml:"decode,omitempty"`
 	Yank            *KeyBindingConfig `yaml:"yank,omitempty"`
 	ApplyFilter     *KeyBindingConfig `yaml:"applyFilter,omitempty"`
 	Right           *KeyBindingConfig `yaml:"right,omitempty"`
 	Left            *KeyBindingConfig `yaml:"left,omitempty"`
+	RunAction       *KeyBindingConfig `yaml:"runAction,omitempty"`
+	ConfigNav       *KeyBindingConfig `yaml:"configNav,omitempty"`
 	ChatNav         *KeyBindingConfig `yaml:"chatNav,omitempty"`
 }
 

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -42,11 +42,15 @@ func ResolveKeyMap(keys KeysConfig) ui.KeyMap {
 	overrideBinding(&km.RelationsNav, keys.RelationsNav, "relations")
 	overrideBinding(&km.SecretsNav, keys.SecretsNav, "secrets")
 	overrideBinding(&km.MachinesNav, keys.MachinesNav, "machines")
+	overrideBinding(&km.OffersNav, keys.OffersNav, "offers")
+	overrideBinding(&km.StorageNav, keys.StorageNav, "storage")
 	overrideBinding(&km.Decode, keys.Decode, "decode")
 	overrideBinding(&km.Yank, keys.Yank, "copy")
 	overrideBinding(&km.ApplyFilter, keys.ApplyFilter, "apply")
 	overrideBinding(&km.Right, keys.Right, "right")
 	overrideBinding(&km.Left, keys.Left, "left")
+	overrideBinding(&km.RunAction, keys.RunAction, "run action")
+	overrideBinding(&km.ConfigNav, keys.ConfigNav, "config")
 	overrideBinding(&km.ChatNav, keys.ChatNav, "chat")
 
 	return km


### PR DESCRIPTION
## Summary
- Added 4 missing key binding configuration fields to `KeysConfig`: `OffersNav`, `StorageNav`, `RunAction`, `ConfigNav`
- Added corresponding `overrideBinding` calls in `ResolveKeyMap` so these bindings can be customized via the config file
- Without this fix, users had no way to remap these 4 key bindings

Fixes #52