### PR TITLE
refactor: extract shared view helpers to reduce code duplication

### DIFF
--- a/internal/view/appconfig/view.go
+++ b/internal/view/appconfig/view.go
@@ -4,7 +4,6 @@ package appconfig
 import (
 	"fmt"
 
-	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
 
@@ -47,9 +46,8 @@ func (v *View) SetSize(width, height int) {
 
 // KeyHints returns the view-specific key hints for the header.
 func (v *View) KeyHints() []view.KeyHint {
-	bk := func(b key.Binding) string { return b.Help().Key }
 	return []view.KeyHint{
-		{Key: bk(v.keys.Back), Desc: "back"},
+		{Key: view.BindingKey(v.keys.Back), Desc: "back"},
 	}
 }
 

--- a/internal/view/applications/view.go
+++ b/internal/view/applications/view.go
@@ -2,8 +2,6 @@
 package applications
 
 import (
-	"strings"
-
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
@@ -52,22 +50,18 @@ func (a *View) SetCharmSuggestions(names []string) {
 
 // KeyHints returns the view-specific key hints for the header.
 func (a *View) KeyHints() []view.KeyHint {
-	bk := func(b key.Binding) string { return b.Help().Key }
 	return []view.KeyHint{
-		{Key: bk(a.keys.Enter), Desc: "units"},
-		{Key: bk(a.keys.ConfigNav), Desc: "config"},
-		{Key: bk(a.keys.Deploy), Desc: "deploy"},
-		{Key: bk(a.keys.LogsJump), Desc: "logs (app)"},
-		{Key: bk(a.keys.LogsView), Desc: "logs"},
+		{Key: view.BindingKey(a.keys.Enter), Desc: "units"},
+		{Key: view.BindingKey(a.keys.ConfigNav), Desc: "config"},
+		{Key: view.BindingKey(a.keys.Deploy), Desc: "deploy"},
+		{Key: view.BindingKey(a.keys.LogsJump), Desc: "logs (app)"},
+		{Key: view.BindingKey(a.keys.LogsView), Desc: "logs"},
 	}
 }
 
 // CopySelection implements view.Copyable.
 func (a *View) CopySelection() string {
-	if row := a.table.SelectedRow(); row != nil {
-		return strings.Join(row, "\t")
-	}
-	return ""
+	return view.CopySelectedRow(a.table)
 }
 
 func (a *View) Init() tea.Cmd { return nil }

--- a/internal/view/chat/view.go
+++ b/internal/view/chat/view.go
@@ -45,11 +45,10 @@ func (v *View) SetStatus(status *model.FullStatus) {
 
 // KeyHints returns the view-specific key hints for the header.
 func (v *View) KeyHints() []view.KeyHint {
-	bk := func(b key.Binding) string { return b.Help().Key }
 	return []view.KeyHint{
 		{Key: "enter", Desc: "send"},
-		{Key: bk(v.keys.Up) + "/" + bk(v.keys.Down), Desc: "scroll"},
-		{Key: bk(v.keys.Back), Desc: "back"},
+		{Key: view.BindingKey(v.keys.Up) + "/" + view.BindingKey(v.keys.Down), Desc: "scroll"},
+		{Key: view.BindingKey(v.keys.Back), Desc: "back"},
 	}
 }
 

--- a/internal/view/controllers/view.go
+++ b/internal/view/controllers/view.go
@@ -2,8 +2,6 @@
 package controllers
 
 import (
-	"strings"
-
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
@@ -44,18 +42,14 @@ func (c *View) SetControllers(ctrls []model.Controller) {
 
 // KeyHints returns the view-specific key hints for the header.
 func (c *View) KeyHints() []view.KeyHint {
-	bk := func(b key.Binding) string { return b.Help().Key }
 	return []view.KeyHint{
-		{Key: bk(c.keys.Enter), Desc: "models"},
+		{Key: view.BindingKey(c.keys.Enter), Desc: "models"},
 	}
 }
 
 // CopySelection implements view.Copyable.
 func (c *View) CopySelection() string {
-	if row := c.table.SelectedRow(); row != nil {
-		return strings.Join(row, "\t")
-	}
-	return ""
+	return view.CopySelectedRow(c.table)
 }
 
 func (c *View) Init() tea.Cmd { return nil }

--- a/internal/view/debuglog/filtermodal.go
+++ b/internal/view/debuglog/filtermodal.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bschimke95/jara/internal/color"
 	"github.com/bschimke95/jara/internal/model"
 	"github.com/bschimke95/jara/internal/ui"
+	"github.com/bschimke95/jara/internal/view"
 )
 
 // logLevels are the valid Juju debug-log severity levels.
@@ -597,22 +598,20 @@ func (m *FilterModal) renderFooter() string {
 	descStyle := lipgloss.NewStyle().Foreground(m.styles.HintDescColor)
 	sep := descStyle.Render("  │  ")
 
-	bk := func(b key.Binding) string { return b.Help().Key }
-
 	var parts []string
-	parts = append(parts, keyStyle.Render("<"+bk(m.keys.Up)+"/"+bk(m.keys.Down)+">")+" "+descStyle.Render("move"))
+	parts = append(parts, keyStyle.Render("<"+view.BindingKey(m.keys.Up)+"/"+view.BindingKey(m.keys.Down)+">")+" "+descStyle.Render("move"))
 	if m.focus == focusLeft {
-		parts = append(parts, keyStyle.Render("<"+bk(m.keys.Enter)+"/"+bk(m.keys.Right)+">")+" "+descStyle.Render("open"))
+		parts = append(parts, keyStyle.Render("<"+view.BindingKey(m.keys.Enter)+"/"+view.BindingKey(m.keys.Right)+">")+" "+descStyle.Render("open"))
 	} else {
 		if m.leftCursor == leftPaneLevel {
-			parts = append(parts, keyStyle.Render("<"+bk(m.keys.Enter)+">")+" "+descStyle.Render("select"))
+			parts = append(parts, keyStyle.Render("<"+view.BindingKey(m.keys.Enter)+">")+" "+descStyle.Render("select"))
 		} else {
-			parts = append(parts, keyStyle.Render("<"+bk(m.keys.Enter)+">")+" "+descStyle.Render("toggle"))
+			parts = append(parts, keyStyle.Render("<"+view.BindingKey(m.keys.Enter)+">")+" "+descStyle.Render("toggle"))
 		}
-		parts = append(parts, keyStyle.Render("<"+bk(m.keys.Left)+"/"+bk(m.keys.Back)+">")+" "+descStyle.Render("back"))
+		parts = append(parts, keyStyle.Render("<"+view.BindingKey(m.keys.Left)+"/"+view.BindingKey(m.keys.Back)+">")+" "+descStyle.Render("back"))
 	}
-	parts = append(parts, keyStyle.Render("<"+bk(m.keys.ApplyFilter)+">")+" "+descStyle.Render("apply"))
-	parts = append(parts, keyStyle.Render("<"+bk(m.keys.Back)+">")+" "+descStyle.Render("close"))
+	parts = append(parts, keyStyle.Render("<"+view.BindingKey(m.keys.ApplyFilter)+">")+" "+descStyle.Render("apply"))
+	parts = append(parts, keyStyle.Render("<"+view.BindingKey(m.keys.Back)+">")+" "+descStyle.Render("close"))
 
 	return " " + strings.Join(parts, sep)
 }

--- a/internal/view/debuglog/view.go
+++ b/internal/view/debuglog/view.go
@@ -67,15 +67,14 @@ func (d *View) SetStatus(s *model.FullStatus) {
 
 // KeyHints returns the view-specific key hints for the header.
 func (d *View) KeyHints() []view.KeyHint {
-	bk := func(b key.Binding) string { return b.Help().Key }
 	return []view.KeyHint{
-		{Key: bk(d.keys.Back), Desc: "back"},
-		{Key: bk(d.keys.Bottom), Desc: "bottom"},
-		{Key: bk(d.keys.Top), Desc: "top"},
-		{Key: bk(d.keys.FilterOpen), Desc: "filter"},
-		{Key: bk(d.keys.ClearFilter), Desc: "clear filter"},
-		{Key: bk(d.keys.SearchOpen), Desc: "search"},
-		{Key: bk(d.keys.SearchNext) + "/" + bk(d.keys.SearchPrev), Desc: "next/prev match"},
+		{Key: view.BindingKey(d.keys.Back), Desc: "back"},
+		{Key: view.BindingKey(d.keys.Bottom), Desc: "bottom"},
+		{Key: view.BindingKey(d.keys.Top), Desc: "top"},
+		{Key: view.BindingKey(d.keys.FilterOpen), Desc: "filter"},
+		{Key: view.BindingKey(d.keys.ClearFilter), Desc: "clear filter"},
+		{Key: view.BindingKey(d.keys.SearchOpen), Desc: "search"},
+		{Key: view.BindingKey(d.keys.SearchNext) + "/" + view.BindingKey(d.keys.SearchPrev), Desc: "next/prev match"},
 	}
 }
 

--- a/internal/view/helpmodal/modal.go
+++ b/internal/view/helpmodal/modal.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bschimke95/jara/internal/color"
 	"github.com/bschimke95/jara/internal/ui"
+	"github.com/bschimke95/jara/internal/view"
 )
 
 // ClosedMsg is emitted when the help modal is dismissed.
@@ -65,16 +66,15 @@ func (m *Modal) View() tea.View {
 
 // generalHints returns the global navigation and common key hints.
 func (m *Modal) generalHints() []ui.KeyHint {
-	bk := func(b key.Binding) string { return b.Help().Key }
 	return []ui.KeyHint{
-		{Key: bk(m.keys.Up) + "/" + bk(m.keys.Down), Desc: "up/down"},
-		{Key: bk(m.keys.PageUp) + "/" + bk(m.keys.PageDown), Desc: "page up/down"},
-		{Key: bk(m.keys.Top) + "/" + bk(m.keys.Bottom), Desc: "top/bottom"},
-		{Key: bk(m.keys.Back), Desc: "back"},
-		{Key: bk(m.keys.Filter), Desc: "filter"},
-		{Key: bk(m.keys.Command), Desc: "cmd"},
-		{Key: bk(m.keys.Help), Desc: "help"},
-		{Key: bk(m.keys.Quit), Desc: "quit"},
+		{Key: view.BindingKey(m.keys.Up) + "/" + view.BindingKey(m.keys.Down), Desc: "up/down"},
+		{Key: view.BindingKey(m.keys.PageUp) + "/" + view.BindingKey(m.keys.PageDown), Desc: "page up/down"},
+		{Key: view.BindingKey(m.keys.Top) + "/" + view.BindingKey(m.keys.Bottom), Desc: "top/bottom"},
+		{Key: view.BindingKey(m.keys.Back), Desc: "back"},
+		{Key: view.BindingKey(m.keys.Filter), Desc: "filter"},
+		{Key: view.BindingKey(m.keys.Command), Desc: "cmd"},
+		{Key: view.BindingKey(m.keys.Help), Desc: "help"},
+		{Key: view.BindingKey(m.keys.Quit), Desc: "quit"},
 	}
 }
 

--- a/internal/view/machines/view.go
+++ b/internal/view/machines/view.go
@@ -2,8 +2,6 @@
 package machines
 
 import (
-	"strings"
-
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
@@ -45,19 +43,15 @@ func (m *View) SetStatus(status *model.FullStatus) {
 
 // KeyHints returns the view-specific key hints for the header.
 func (m *View) KeyHints() []view.KeyHint {
-	bk := func(b key.Binding) string { return b.Help().Key }
 	return []view.KeyHint{
-		{Key: bk(m.keys.LogsJump), Desc: "logs (machine)"},
-		{Key: bk(m.keys.LogsView), Desc: "logs"},
+		{Key: view.BindingKey(m.keys.LogsJump), Desc: "logs (machine)"},
+		{Key: view.BindingKey(m.keys.LogsView), Desc: "logs"},
 	}
 }
 
 // CopySelection implements view.Copyable.
 func (m *View) CopySelection() string {
-	if row := m.table.SelectedRow(); row != nil {
-		return strings.Join(row, "\t")
-	}
-	return ""
+	return view.CopySelectedRow(m.table)
 }
 
 func (m *View) Init() tea.Cmd { return nil }

--- a/internal/view/models/view.go
+++ b/internal/view/models/view.go
@@ -2,8 +2,6 @@
 package models
 
 import (
-	"strings"
-
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
@@ -44,18 +42,14 @@ func (m *View) SetModels(mdls []model.ModelSummary) {
 
 // KeyHints returns the view-specific key hints for the header.
 func (m *View) KeyHints() []view.KeyHint {
-	bk := func(b key.Binding) string { return b.Help().Key }
 	return []view.KeyHint{
-		{Key: bk(m.keys.Enter), Desc: "open model"},
+		{Key: view.BindingKey(m.keys.Enter), Desc: "open model"},
 	}
 }
 
 // CopySelection implements view.Copyable.
 func (m *View) CopySelection() string {
-	if row := m.table.SelectedRow(); row != nil {
-		return strings.Join(row, "\t")
-	}
-	return ""
+	return view.CopySelectedRow(m.table)
 }
 
 func (m *View) Init() tea.Cmd { return nil }

--- a/internal/view/modelview/rows.go
+++ b/internal/view/modelview/rows.go
@@ -2,7 +2,6 @@ package modelview
 
 import (
 	"fmt"
-	"strings"
 
 	"charm.land/bubbles/v2/table"
 
@@ -45,15 +44,4 @@ func applicationRows(apps map[string]model.Application, s *color.Styles) []table
 		})
 	}
 	return result
-}
-
-func padToHeight(content string, height int) string {
-	lines := strings.Split(content, "\n")
-	for len(lines) < height {
-		lines = append(lines, "")
-	}
-	if len(lines) > height {
-		lines = lines[:height]
-	}
-	return strings.Join(lines, "\n")
 }

--- a/internal/view/modelview/rows_test.go
+++ b/internal/view/modelview/rows_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bschimke95/jara/internal/color"
 	"github.com/bschimke95/jara/internal/model"
+	"github.com/bschimke95/jara/internal/view"
 )
 
 func TestApplicationColumns(t *testing.T) {
@@ -69,7 +70,7 @@ func TestPadToHeight(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := padToHeight(tt.content, tt.height)
+			got := view.PadToHeight(tt.content, tt.height)
 			lines := 1
 			for _, c := range got {
 				if c == '\n' {

--- a/internal/view/modelview/view.go
+++ b/internal/view/modelview/view.go
@@ -3,8 +3,6 @@
 package modelview
 
 import (
-	"strings"
-
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
@@ -103,26 +101,22 @@ func (m *View) SetCharmEndpoints(endpoints map[string]map[string]model.CharmEndp
 
 // KeyHints returns the view-specific key hints for the header.
 func (m *View) KeyHints() []view.KeyHint {
-	bk := func(b key.Binding) string { return b.Help().Key }
 	return []view.KeyHint{
-		{Key: bk(m.keys.Enter), Desc: "select"},
-		{Key: bk(m.keys.Deploy), Desc: "deploy"},
-		{Key: bk(m.keys.Relate), Desc: "relate"},
-		{Key: bk(m.keys.ApplicationsNav), Desc: "apps"},
-		{Key: bk(m.keys.UnitsNav), Desc: "units"},
-		{Key: bk(m.keys.RelationsNav), Desc: "relations"},
-		{Key: bk(m.keys.ScaleUp) + "/" + bk(m.keys.ScaleDown), Desc: "scale"},
-		{Key: bk(m.keys.LogsJump), Desc: "logs (app)"},
-		{Key: bk(m.keys.LogsView), Desc: "logs"},
+		{Key: view.BindingKey(m.keys.Enter), Desc: "select"},
+		{Key: view.BindingKey(m.keys.Deploy), Desc: "deploy"},
+		{Key: view.BindingKey(m.keys.Relate), Desc: "relate"},
+		{Key: view.BindingKey(m.keys.ApplicationsNav), Desc: "apps"},
+		{Key: view.BindingKey(m.keys.UnitsNav), Desc: "units"},
+		{Key: view.BindingKey(m.keys.RelationsNav), Desc: "relations"},
+		{Key: view.BindingKey(m.keys.ScaleUp) + "/" + view.BindingKey(m.keys.ScaleDown), Desc: "scale"},
+		{Key: view.BindingKey(m.keys.LogsJump), Desc: "logs (app)"},
+		{Key: view.BindingKey(m.keys.LogsView), Desc: "logs"},
 	}
 }
 
 // CopySelection implements view.Copyable.
 func (m *View) CopySelection() string {
-	if row := m.appTable.SelectedRow(); row != nil {
-		return strings.Join(row, "\t")
-	}
-	return ""
+	return view.CopySelectedRow(m.appTable)
 }
 
 // NoModelMsg is sent by the status stream when no model is selected on the
@@ -259,7 +253,7 @@ func (m *View) renderBackground() string {
 
 	leftContent := m.appTableView()
 	leftBox := ui.BorderBoxRawTitle(
-		padToHeight(leftContent, m.height-2),
+		view.PadToHeight(leftContent, m.height-2),
 		m.leftPaneTitle("A", "pplications"),
 		leftWidth,
 		m.styles,
@@ -271,13 +265,13 @@ func (m *View) renderBackground() string {
 	}
 
 	unitBox := ui.BorderBoxRawTitle(
-		padToHeight(m.unitTable.View(), halfH),
+		view.PadToHeight(m.unitTable.View(), halfH),
 		m.rightPaneTitle("U", "nits"),
 		rightWidth,
 		m.styles,
 	)
 	relBox := ui.BorderBoxRawTitle(
-		padToHeight(m.relationTable.View(), halfH),
+		view.PadToHeight(m.relationTable.View(), halfH),
 		m.rightPaneTitle("R", "elations"),
 		rightWidth,
 		m.styles,

--- a/internal/view/overview/view.go
+++ b/internal/view/overview/view.go
@@ -35,9 +35,8 @@ func (o *View) SetStatus(status *model.FullStatus) {
 
 // KeyHints returns the view-specific key hints for the header.
 func (o *View) KeyHints() []view.KeyHint {
-	bk := func(b key.Binding) string { return b.Help().Key }
 	return []view.KeyHint{
-		{Key: bk(o.keys.Enter), Desc: "applications"},
+		{Key: view.BindingKey(o.keys.Enter), Desc: "applications"},
 	}
 }
 

--- a/internal/view/relations/databag.go
+++ b/internal/view/relations/databag.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bschimke95/jara/internal/color"
 	"github.com/bschimke95/jara/internal/model"
 	"github.com/bschimke95/jara/internal/ui"
+	"github.com/bschimke95/jara/internal/view"
 )
 
 // appColors is a palette of border colours assigned to each application in a
@@ -28,7 +29,7 @@ var appColors = []icolor.Color{
 func renderDatabagPane(rd *model.RelationData, rel *model.Relation, width, height int, focus databagFocus, appScroll, unitScroll int, s *color.Styles) string {
 	if rd == nil || rel == nil {
 		placeholder := lipgloss.NewStyle().Foreground(s.Muted).Render("Select a relation to view databag contents")
-		return ui.BorderBox(padToHeight(placeholder, height-2), "Databags", width, s)
+		return ui.BorderBox(view.PadToHeight(placeholder, height-2), "Databags", width, s)
 	}
 
 	innerWidth := width - 2 // outer border
@@ -310,15 +311,4 @@ func sortedKV(data map[string]string, maxWidth int) []kvPair {
 		pairs = append(pairs, kvPair{key: padded, val: val})
 	}
 	return pairs
-}
-
-func padToHeight(content string, height int) string {
-	lines := strings.Split(content, "\n")
-	for len(lines) < height {
-		lines = append(lines, "")
-	}
-	if len(lines) > height {
-		lines = lines[:height]
-	}
-	return strings.Join(lines, "\n")
 }

--- a/internal/view/relations/databag_test.go
+++ b/internal/view/relations/databag_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bschimke95/jara/internal/color"
 	"github.com/bschimke95/jara/internal/model"
+	"github.com/bschimke95/jara/internal/view"
 )
 
 func TestRenderDatabagPane_NilData(t *testing.T) {
@@ -113,7 +114,7 @@ func TestSortedKV(t *testing.T) {
 
 func TestPadToHeight(t *testing.T) {
 	content := "line1\nline2"
-	result := padToHeight(content, 5)
+	result := view.PadToHeight(content, 5)
 	lines := strings.Split(result, "\n")
 	if len(lines) != 5 {
 		t.Errorf("padToHeight() produced %d lines, want 5", len(lines))

--- a/internal/view/relations/view.go
+++ b/internal/view/relations/view.go
@@ -70,10 +70,9 @@ func (r *View) SetRelationData(data *model.RelationData) {
 
 // KeyHints returns the view-specific key hints for the header.
 func (r *View) KeyHints() []view.KeyHint {
-	bk := func(b key.Binding) string { return b.Help().Key }
 	hints := []view.KeyHint{
-		{Key: bk(r.keys.DeleteRelation), Desc: "delete"},
-		{Key: bk(r.keys.LogsJump), Desc: "logs"},
+		{Key: view.BindingKey(r.keys.DeleteRelation), Desc: "delete"},
+		{Key: view.BindingKey(r.keys.LogsJump), Desc: "logs"},
 	}
 	if r.focus != focusTable {
 		hints = append(hints, view.KeyHint{Key: "tab", Desc: "switch pane"})
@@ -83,10 +82,7 @@ func (r *View) KeyHints() []view.KeyHint {
 
 // CopySelection implements view.Copyable.
 func (r *View) CopySelection() string {
-	if row := r.table.SelectedRow(); row != nil {
-		return strings.Join(row, "\t")
-	}
-	return ""
+	return view.CopySelectedRow(r.table)
 }
 
 func (r *View) Init() tea.Cmd { return nil }
@@ -293,7 +289,7 @@ func (r *View) SetFilter(s string) {
 func (r *View) renderSplitPane() string {
 	leftWidth, rightWidth := r.splitWidths()
 
-	leftContent := padToHeight(r.table.View(), r.height-2)
+	leftContent := view.PadToHeight(r.table.View(), r.height-2)
 	leftBox := ui.BorderBox(leftContent, r.leftPaneTitle(), leftWidth, r.styles)
 
 	sel := r.selectedRelation()

--- a/internal/view/secretdetail/view.go
+++ b/internal/view/secretdetail/view.go
@@ -57,11 +57,10 @@ func (v *View) SetStatus(status *model.FullStatus) {
 
 // KeyHints returns the view-specific key hints for the header.
 func (v *View) KeyHints() []view.KeyHint {
-	bk := func(b key.Binding) string { return b.Help().Key }
 	return []view.KeyHint{
-		{Key: bk(v.keys.Decode), Desc: "decode"},
-		{Key: bk(v.keys.Tab), Desc: "switch"},
-		{Key: bk(v.keys.Back), Desc: "back"},
+		{Key: view.BindingKey(v.keys.Decode), Desc: "decode"},
+		{Key: view.BindingKey(v.keys.Tab), Desc: "switch"},
+		{Key: view.BindingKey(v.keys.Back), Desc: "back"},
 	}
 }
 
@@ -137,7 +136,7 @@ func (v *View) View() tea.View {
 	leftContent := v.renderMetadata()
 	titleStyle := lipgloss.NewStyle().Foreground(v.styles.BorderTitleColor).Bold(true)
 	leftBox := ui.BorderBoxRawTitle(
-		padToHeight(leftContent, v.height-2),
+		view.PadToHeight(leftContent, v.height-2),
 		titleStyle.Render(" Details "),
 		leftW,
 		v.styles,
@@ -150,13 +149,13 @@ func (v *View) View() tea.View {
 	}
 
 	revBox := ui.BorderBoxRawTitle(
-		padToHeight(v.revTable.View(), halfH),
+		view.PadToHeight(v.revTable.View(), halfH),
 		titleStyle.Render(" Revisions "),
 		rightW,
 		v.styles,
 	)
 	accBox := ui.BorderBoxRawTitle(
-		padToHeight(v.accessTable.View(), halfH),
+		view.PadToHeight(v.accessTable.View(), halfH),
 		titleStyle.Render(" Access "),
 		rightW,
 		v.styles,
@@ -335,13 +334,3 @@ func (v *View) splitWidths() (int, int) {
 }
 
 // padToHeight pads or truncates content to exactly the given number of lines.
-func padToHeight(content string, height int) string {
-	lines := strings.Split(content, "\n")
-	for len(lines) < height {
-		lines = append(lines, "")
-	}
-	if len(lines) > height {
-		lines = lines[:height]
-	}
-	return strings.Join(lines, "\n")
-}

--- a/internal/view/secrets/view.go
+++ b/internal/view/secrets/view.go
@@ -2,8 +2,6 @@
 package secrets
 
 import (
-	"strings"
-
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
@@ -45,19 +43,15 @@ func (s *View) SetStatus(status *model.FullStatus) {
 
 // KeyHints returns the view-specific key hints for the header.
 func (s *View) KeyHints() []view.KeyHint {
-	bk := func(b key.Binding) string { return b.Help().Key }
 	return []view.KeyHint{
-		{Key: bk(s.keys.Enter), Desc: "detail"},
-		{Key: bk(s.keys.LogsView), Desc: "logs"},
+		{Key: view.BindingKey(s.keys.Enter), Desc: "detail"},
+		{Key: view.BindingKey(s.keys.LogsView), Desc: "logs"},
 	}
 }
 
 // CopySelection implements view.Copyable.
 func (s *View) CopySelection() string {
-	if row := s.table.SelectedRow(); row != nil {
-		return strings.Join(row, "\t")
-	}
-	return ""
+	return view.CopySelectedRow(s.table)
 }
 
 func (s *View) Init() tea.Cmd { return nil }

--- a/internal/view/units/view.go
+++ b/internal/view/units/view.go
@@ -65,21 +65,17 @@ func (u *View) SetStatus(status *model.FullStatus) {
 
 // KeyHints returns the view-specific key hints for the header.
 func (u *View) KeyHints() []view.KeyHint {
-	bk := func(b key.Binding) string { return b.Help().Key }
 	return []view.KeyHint{
-		{Key: bk(u.keys.RunAction), Desc: "action"},
-		{Key: bk(u.keys.ScaleUp) + "/" + bk(u.keys.ScaleDown), Desc: "scale"},
-		{Key: bk(u.keys.LogsJump), Desc: "logs (unit)"},
-		{Key: bk(u.keys.LogsView), Desc: "logs"},
+		{Key: view.BindingKey(u.keys.RunAction), Desc: "action"},
+		{Key: view.BindingKey(u.keys.ScaleUp) + "/" + view.BindingKey(u.keys.ScaleDown), Desc: "scale"},
+		{Key: view.BindingKey(u.keys.LogsJump), Desc: "logs (unit)"},
+		{Key: view.BindingKey(u.keys.LogsView), Desc: "logs"},
 	}
 }
 
 // CopySelection implements view.Copyable.
 func (u *View) CopySelection() string {
-	if row := u.table.SelectedRow(); row != nil {
-		return strings.Join(row, "\t")
-	}
-	return ""
+	return view.CopySelectedRow(u.table)
 }
 
 // rebuildRows recomputes the table rows from the current status + pending deltas.

--- a/internal/view/view.go
+++ b/internal/view/view.go
@@ -4,6 +4,10 @@
 package view
 
 import (
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
 	"github.com/bschimke95/jara/internal/model"
 	"github.com/bschimke95/jara/internal/nav"
@@ -174,4 +178,32 @@ type Copyable interface {
 // The app uses this to show a brief notification.
 type ClipboardMsg struct {
 	Text string
+}
+
+// BindingKey returns the display key string for a key binding.
+// This replaces the common inline closure `bk := func(b key.Binding) string { return b.Help().Key }`.
+func BindingKey(b key.Binding) string {
+	return b.Help().Key
+}
+
+// CopySelectedRow returns the selected table row as a tab-separated string,
+// or an empty string if nothing is selected.
+func CopySelectedRow(t table.Model) string {
+	if row := t.SelectedRow(); row != nil {
+		return strings.Join(row, "\t")
+	}
+	return ""
+}
+
+// PadToHeight pads or truncates a rendered string so it has exactly the
+// given number of lines.
+func PadToHeight(content string, height int) string {
+	lines := strings.Split(content, "\n")
+	for len(lines) < height {
+		lines = append(lines, "")
+	}
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
## Summary
- Extracted `view.BindingKey(b)` — eliminates 15 copies of the `bk` closure across view packages
- Extracted `view.CopySelectedRow(t)` — eliminates 8 copies of the `CopySelection` method body
- Extracted `view.PadToHeight(s, h)` — eliminates 3 copies of the `padToHeight` private function
- Net result: 20 files changed, ~50 lines removed, all behavior preserved
- Updated all consuming packages and tests

Fixes #55