### PR TITLE
fix: add input validation across API, config, and navigation layers

### DIFF
--- a/internal/api/juju.go
+++ b/internal/api/juju.go
@@ -492,6 +492,10 @@ func (c *JujuClient) Status(ctx context.Context) (*model.FullStatus, error) {
 // For IAAS (machine) models it uses AddUnits / DestroyUnits instead,
 // because the ScaleApplication API is only supported on container models.
 func (c *JujuClient) ScaleApplication(ctx context.Context, appName string, delta int) error {
+	if delta == 0 {
+		return nil
+	}
+
 	conn, err := c.connect(ctx)
 	if err != nil {
 		return err
@@ -635,6 +639,10 @@ func (c *JujuClient) DeployApplication(ctx context.Context, opts model.DeployOpt
 // RelateApplications adds a relation between two endpoints using the
 // Application facade's AddRelation call.
 func (c *JujuClient) RelateApplications(ctx context.Context, endpointA, endpointB string) error {
+	if endpointA == "" || endpointB == "" {
+		return fmt.Errorf("both endpoints must be non-empty")
+	}
+
 	conn, err := c.connect(ctx)
 	if err != nil {
 		return err
@@ -651,6 +659,10 @@ func (c *JujuClient) RelateApplications(ctx context.Context, endpointA, endpoint
 // DestroyRelation removes a relation between two endpoints using the
 // Application facade's DestroyRelation call.
 func (c *JujuClient) DestroyRelation(ctx context.Context, endpointA, endpointB string) error {
+	if endpointA == "" || endpointB == "" {
+		return fmt.Errorf("both endpoints must be non-empty")
+	}
+
 	conn, err := c.connect(ctx)
 	if err != nil {
 		return err
@@ -893,6 +905,10 @@ func (c *JujuClient) ListOffers(ctx context.Context) ([]model.Offer, error) {
 
 // AppConfig returns the configuration key-value pairs for an application.
 func (c *JujuClient) AppConfig(ctx context.Context, appName string) ([]model.ConfigEntry, error) {
+	if appName == "" {
+		return nil, fmt.Errorf("application name must be non-empty")
+	}
+
 	conn, err := c.connect(ctx)
 	if err != nil {
 		return nil, err
@@ -933,6 +949,10 @@ func (c *JujuClient) AppConfig(ctx context.Context, appName string) ([]model.Con
 
 // ApplicationActions returns the available charm actions for an application.
 func (c *JujuClient) ApplicationActions(ctx context.Context, appName string) ([]model.ActionSpec, error) {
+	if appName == "" {
+		return nil, fmt.Errorf("application name must be non-empty")
+	}
+
 	conn, err := c.connect(ctx)
 	if err != nil {
 		return nil, err
@@ -958,6 +978,13 @@ func (c *JujuClient) ApplicationActions(ctx context.Context, appName string) ([]
 
 // RunAction executes a named action on a unit and waits for the result.
 func (c *JujuClient) RunAction(ctx context.Context, unitName, actionName string, params map[string]string) (*model.ActionResult, error) {
+	if unitName == "" {
+		return nil, fmt.Errorf("unit name must be non-empty")
+	}
+	if actionName == "" {
+		return nil, fmt.Errorf("action name must be non-empty")
+	}
+
 	conn, err := c.connect(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -271,6 +272,24 @@ func (c *Config) Load(path string) error {
 	}
 	if c.Jara.CharmhubURL == "" {
 		c.Jara.CharmhubURL = DefaultCharmhubURL
+	}
+
+	// Clamp RefreshRate to a sensible range.
+	minRate := 0.5  // 500ms
+	maxRate := 60.0 // 60s
+	if c.Jara.RefreshRate < minRate {
+		c.Jara.RefreshRate = minRate
+	}
+	if c.Jara.RefreshRate > maxRate {
+		c.Jara.RefreshRate = maxRate
+	}
+
+	// Validate LogLevel.
+	switch strings.ToLower(c.Jara.LogLevel) {
+	case "error", "warn", "info", "debug", "trace":
+		c.Jara.LogLevel = strings.ToLower(c.Jara.LogLevel)
+	default:
+		c.Jara.LogLevel = DefaultLogLevel
 	}
 
 	return nil

--- a/internal/nav/nav.go
+++ b/internal/nav/nav.go
@@ -102,6 +102,7 @@ var CommandAliases = map[string]ViewID{
 
 // ResolveCommand looks up a command string and returns the matching ViewID.
 func ResolveCommand(cmd string) (ViewID, bool) {
+	cmd = strings.ToLower(cmd)
 	v, ok := CommandAliases[cmd]
 	return v, ok
 }


### PR DESCRIPTION
## Summary
- Added validation to 6 API methods to reject invalid inputs before opening connections (empty strings, zero deltas)
- Config: clamp `RefreshRate` to [500ms, 60s], validate `LogLevel` against allowed values
- Navigation: normalize `ResolveCommand` input to lowercase so "Units" and "UNITS" work like "units"

Fixes #57