### PR TITLE
refactor: replace type assertion with Filterable interface for view filtering

### DIFF
--- a/internal/app/input.go
+++ b/internal/app/input.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bschimke95/jara/internal/nav"
 	"github.com/bschimke95/jara/internal/ui"
 	"github.com/bschimke95/jara/internal/view"
-	"github.com/bschimke95/jara/internal/view/relations"
 )
 
 type inputMode int
@@ -208,10 +207,10 @@ func (m Model) renderFilterBar() string {
 }
 
 // applyFilterToActiveView passes the current filter string to views that
-// support view-level filtering (e.g. the relations view).
+// implement the view.Filterable interface.
 func (m *Model) applyFilterToActiveView() {
-	if rv, ok := m.views[m.stack.Current().View].(*relations.View); ok {
-		rv.SetFilter(m.filterStr)
+	if fv, ok := m.views[m.stack.Current().View].(view.Filterable); ok {
+		fv.SetFilter(m.filterStr)
 	}
 }
 

--- a/internal/app/navigate.go
+++ b/internal/app/navigate.go
@@ -59,6 +59,9 @@ func (m Model) handleBack() (Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
+		// Clear any leftover filter from the child view.
+		m.filterStr = ""
+
 		current := m.stack.Current()
 		// Re-size the view we are returning to so it uses the correct contentHeight.
 		m.views[current.View].SetSize(m.width, m.contentHeight())

--- a/internal/view/view.go
+++ b/internal/view/view.go
@@ -174,6 +174,13 @@ type Copyable interface {
 	CopySelection() string
 }
 
+// Filterable is an optional interface for views that support inline text
+// filtering. The app calls SetFilter with the current filter string whenever
+// the user types in the filter bar.
+type Filterable interface {
+	SetFilter(filter string)
+}
+
 // ClipboardMsg is sent when text has been copied to the clipboard.
 // The app uses this to show a brief notification.
 type ClipboardMsg struct {


### PR DESCRIPTION
## Summary
- Added `view.Filterable` interface with `SetFilter(string)` method
- Replaced hard-coded `*relations.View` type assertion with interface check, so any view can opt into filtering
- Cleared `filterStr` on back navigation to prevent stale filters persisting across views
- Removed direct `relations` package import from `input.go`

Fixes #61