### PR TITLE
fix: replace hardcoded values with named constants and config fields

### DIFF
--- a/internal/api/juju.go
+++ b/internal/api/juju.go
@@ -36,6 +36,19 @@ import (
 	"github.com/bschimke95/jara/internal/model"
 )
 
+const (
+	// actionPollInterval is the time between polls when waiting for an
+	// action to complete.
+	actionPollInterval = 500 * time.Millisecond
+
+	// statusFetchTimeout is the per-call timeout for fetching Juju status.
+	statusFetchTimeout = 10 * time.Second
+
+	// defaultDebugLogBacklog is the number of recent log lines fetched when
+	// starting a debug-log stream and no explicit backlog is configured.
+	defaultDebugLogBacklog uint = 100
+)
+
 // nopLogger is a no-op implementation of core/logger.Logger.
 type nopLogger struct{}
 
@@ -1014,7 +1027,7 @@ func (c *JujuClient) RunAction(ctx context.Context, unitName, actionName string,
 	actionID := enqueued.Actions[0].Action.ID
 
 	// Poll for completion.
-	ticker := time.NewTicker(500 * time.Millisecond)
+	ticker := time.NewTicker(actionPollInterval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -1068,13 +1081,7 @@ func (c *JujuClient) ListStorage(ctx context.Context) ([]model.StorageInstance, 
 
 	result := make([]model.StorageInstance, 0, len(details))
 	for _, d := range details {
-		kind := "unknown"
-		switch d.Kind {
-		case 1:
-			kind = "block"
-		case 2:
-			kind = "filesystem"
-		}
+		kind := d.Kind.String()
 		si := model.StorageInstance{
 			ID:         strings.TrimPrefix(d.StorageTag, "storage-"),
 			Kind:       kind,
@@ -1155,7 +1162,7 @@ func (c *JujuClient) DebugLog(ctx context.Context, filter model.DebugLogFilter) 
 	}
 
 	params := common.DebugLogParams{
-		Backlog: 100,
+		Backlog: defaultDebugLogBacklog,
 	}
 	if filter.Backlog > 0 {
 		params.Backlog = uint(filter.Backlog)
@@ -1258,7 +1265,7 @@ func (c *JujuClient) WatchStatus(ctx context.Context, interval time.Duration) (<
 
 			// Fetch status on the persistent connection.
 			statusClient := client.NewClient(conn, nopLogger{})
-			fetchCtx, fetchCancel := context.WithTimeout(ctx, 10*time.Second)
+			fetchCtx, fetchCancel := context.WithTimeout(ctx, statusFetchTimeout)
 			result, err := statusClient.Status(fetchCtx, &client.StatusArgs{
 				Patterns: []string{},
 			})

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -643,6 +643,7 @@ func initLLMClient(cfg *config.Config) (llm.Client, error) {
 	case "copilot":
 		opts := []llm.CopilotOption{
 			llm.WithCopilotModel(aiCfg.Model),
+			llm.WithCopilotLogLevel(cfg.Jara.LogLevel),
 		}
 		if cred != "" {
 			opts = append(opts, llm.WithCopilotGitHubToken(cred))
@@ -662,19 +663,16 @@ func initLLMClient(cfg *config.Config) (llm.Client, error) {
 		if cred == "" {
 			return nil, nil
 		}
-		temp := 0.7
-		if aiCfg.Temperature != nil {
-			temp = *aiCfg.Temperature
-		}
-		maxTokens := 4096
-		if aiCfg.MaxTokens != nil {
-			maxTokens = *aiCfg.MaxTokens
-		}
-		c, err := llm.NewGeminiClient(context.Background(), cred,
+		opts := []llm.GeminiOption{
 			llm.WithGeminiModel(aiCfg.Model),
-			llm.WithGeminiTemperature(temp),
-			llm.WithGeminiMaxTokens(maxTokens),
-		)
+		}
+		if aiCfg.Temperature != nil {
+			opts = append(opts, llm.WithGeminiTemperature(*aiCfg.Temperature))
+		}
+		if aiCfg.MaxTokens != nil {
+			opts = append(opts, llm.WithGeminiMaxTokens(*aiCfg.MaxTokens))
+		}
+		c, err := llm.NewGeminiClient(context.Background(), cred, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/color/styles.go
+++ b/internal/color/styles.go
@@ -62,6 +62,9 @@ type Styles struct {
 	// CheckRedColor is the raw color for negative check marks.
 	CheckRedColor color.Color
 
+	// AssistantLabelColor is the raw color for the "Assistant:" label in chat.
+	AssistantLabelColor color.Color
+
 	// InfoLabelColor is the raw color for info labels.
 	InfoLabelColor color.Color
 
@@ -163,6 +166,9 @@ type Styles struct {
 	// CheckRed is the style for negative/unchecked marks.
 	CheckRed lipgloss.Style
 
+	// AssistantLabel is the bold style for the "Assistant:" label in chat.
+	AssistantLabel lipgloss.Style
+
 	// Pending is italic muted text for placeholder/pending rows.
 	Pending lipgloss.Style
 }
@@ -217,6 +223,7 @@ type palette struct {
 	crumbBgAlt        color.Color
 	checkGreen        color.Color
 	checkRed          color.Color
+	assistantLabel    color.Color
 	statusColors      map[string]color.Color
 }
 
@@ -244,6 +251,7 @@ func defaultPalette() palette {
 		crumbBgAlt:        lipgloss.Color("#3e4451"),
 		checkGreen:        lipgloss.Color("#98c379"),
 		checkRed:          lipgloss.Color("#e06c75"),
+		assistantLabel:    lipgloss.Color("#98c379"),
 		statusColors: map[string]color.Color{
 			"active":      lipgloss.Color("#00ff00"),
 			"idle":        lipgloss.Color("#00ff00"),
@@ -286,6 +294,7 @@ func newStyles(p palette) *Styles {
 		ErrorColor:             p.errorColor,
 		CheckGreenColor:        p.checkGreen,
 		CheckRedColor:          p.checkRed,
+		AssistantLabelColor:    p.assistantLabel,
 		InfoLabelColor:         p.infoLabel,
 		InfoValueColor:         p.infoValue,
 		BorderColor:            p.border,
@@ -359,6 +368,8 @@ func (s *Styles) RebuildStyles() {
 
 	s.CheckGreen = lipgloss.NewStyle().Foreground(s.CheckGreenColor).Bold(true)
 	s.CheckRed = lipgloss.NewStyle().Foreground(s.CheckRedColor)
+
+	s.AssistantLabel = lipgloss.NewStyle().Foreground(s.AssistantLabelColor).Bold(true)
 
 	s.Pending = lipgloss.NewStyle().Foreground(s.Muted).Italic(true)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,6 +160,9 @@ type SkinConfig struct {
 	// CheckRed is the color for negative/unchecked marks.
 	CheckRed string `yaml:"checkRed,omitempty"`
 
+	// AssistantLabel is the color for the "Assistant:" label in chat.
+	AssistantLabel string `yaml:"assistantLabel,omitempty"`
+
 	// Status maps Juju status strings to hex colors for overrides.
 	Status StatusColorsConfig `yaml:"status,omitempty"`
 }

--- a/internal/config/styles.go
+++ b/internal/config/styles.go
@@ -33,6 +33,7 @@ func ResolveStyles(skin SkinConfig) *color.Styles {
 	applyColorOverride(&s.ErrorColor, skin.Error)
 	applyColorOverride(&s.CheckGreenColor, skin.CheckGreen)
 	applyColorOverride(&s.CheckRedColor, skin.CheckRed)
+	applyColorOverride(&s.AssistantLabelColor, skin.AssistantLabel)
 	applyColorOverride(&s.InfoLabelColor, skin.InfoLabel)
 	applyColorOverride(&s.InfoValueColor, skin.InfoValue)
 	applyColorOverride(&s.BorderColor, skin.Border)

--- a/internal/llm/copilot.go
+++ b/internal/llm/copilot.go
@@ -21,6 +21,7 @@ type CopilotClient struct {
 	sdkClient   *copilot.Client
 	model       string
 	githubToken string
+	logLevel    string
 
 	mu      sync.Mutex
 	started bool
@@ -46,6 +47,16 @@ func WithCopilotGitHubToken(token string) CopilotOption {
 	}
 }
 
+// WithCopilotLogLevel sets the log level for the Copilot SDK.
+// Valid values are "error", "warn", "info", "debug". Defaults to "error".
+func WithCopilotLogLevel(level string) CopilotOption {
+	return func(c *CopilotClient) {
+		if level != "" {
+			c.logLevel = level
+		}
+	}
+}
+
 // NewCopilotClient creates a Copilot-backed LLM client using the official SDK.
 // The Copilot CLI binary must be installed on the system and available in PATH.
 // Authentication is handled via environment variables (GITHUB_TOKEN, GH_TOKEN,
@@ -64,14 +75,15 @@ func NewCopilotClient(opts ...CopilotOption) (*CopilotClient, error) {
 	}
 
 	c := &CopilotClient{
-		model: copilotDefaultModel,
+		model:    copilotDefaultModel,
+		logLevel: "error",
 	}
 	for _, opt := range opts {
 		opt(c)
 	}
 
 	clientOpts := &copilot.ClientOptions{
-		LogLevel: "error",
+		LogLevel: c.logLevel,
 		CLIPath:  cliPath,
 	}
 	if c.githubToken != "" {

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -7,7 +7,11 @@ import (
 	"google.golang.org/genai"
 )
 
-const defaultGeminiModel = "gemini-2.0-flash"
+const (
+	defaultGeminiModel       = "gemini-2.0-flash"
+	defaultGeminiTemperature = 0.7
+	defaultGeminiMaxTokens   = 4096
+)
 
 // GeminiClient implements Client using the Google Gemini API.
 type GeminiClient struct {
@@ -58,8 +62,8 @@ func NewGeminiClient(ctx context.Context, apiKey string, opts ...GeminiOption) (
 	g := &GeminiClient{
 		client:      client,
 		model:       defaultGeminiModel,
-		temperature: 0.7,
-		maxTokens:   4096,
+		temperature: defaultGeminiTemperature,
+		maxTokens:   defaultGeminiMaxTokens,
 	}
 	for _, opt := range opts {
 		opt(g)

--- a/internal/view/chat/view.go
+++ b/internal/view/chat/view.go
@@ -458,7 +458,7 @@ func (v *View) renderMessages() string {
 	}
 
 	userStyle := lipgloss.NewStyle().Foreground(v.styles.Primary).Bold(true)
-	assistantLabel := lipgloss.NewStyle().Foreground(lipgloss.Color("#98c379")).Bold(true)
+	assistantLabel := v.styles.AssistantLabel
 	contentStyle := lipgloss.NewStyle().Foreground(v.styles.Title)
 	mutedStyle := lipgloss.NewStyle().Foreground(v.styles.Muted)
 


### PR DESCRIPTION
## Summary

- Extract action poll interval, status fetch timeout, and debug log backlog into named constants in `api/juju.go`
- Replace storage kind magic numbers (1, 2) with Juju SDK's `StorageKind.String()` method
- Add `AssistantLabel` color to `SkinConfig`/`Styles` so the chat assistant label color is themeable instead of hardcoded
- Make Copilot SDK log level configurable via `WithCopilotLogLevel`, wired to the app's configured `LogLevel`
- Extract Gemini default temperature/maxTokens into named constants and remove duplicated defaults from the call site

Closes #63