### PR TITLE
fix: add empty states, error display, and debug log multi-highlight

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -451,6 +451,10 @@ func (m Model) contentHeight() int {
 			chrome += 3
 		}
 	}
+	// Account for the error line when one is present.
+	if m.err != nil {
+		chrome++
+	}
 	h := m.height - chrome
 	if h < 5 {
 		h = 5

--- a/internal/view/debuglog/format.go
+++ b/internal/view/debuglog/format.go
@@ -18,14 +18,24 @@ func containsIgnoreCase(s, substr string) bool {
 func highlightSearchMatch(line, query string, s *color.Styles) string {
 	lower := strings.ToLower(line)
 	lq := strings.ToLower(query)
-	idx := strings.Index(lower, lq)
-	if idx < 0 {
-		return line
-	}
+	ql := len(query)
 	hl := lipgloss.NewStyle().
 		Foreground(s.SearchHighlightFgColor).
 		Background(s.SearchHighlightBgColor)
-	return line[:idx] + hl.Render(line[idx:idx+len(query)]) + line[idx+len(query):]
+
+	var b strings.Builder
+	pos := 0
+	for {
+		idx := strings.Index(lower[pos:], lq)
+		if idx < 0 {
+			b.WriteString(line[pos:])
+			break
+		}
+		b.WriteString(line[pos : pos+idx])
+		b.WriteString(hl.Render(line[pos+idx : pos+idx+ql]))
+		pos += idx + ql
+	}
+	return b.String()
 }
 
 func severityColor(severity string, s *color.Styles) lipgloss.Style {

--- a/internal/view/offers/types.go
+++ b/internal/view/offers/types.go
@@ -19,9 +19,11 @@ type OffersDataMsg struct {
 
 // View is the Bubble Tea model for the offers table view.
 type View struct {
-	table  table.Model
-	keys   ui.KeyMap
-	styles *color.Styles
-	width  int
-	height int
+	table   table.Model
+	keys    ui.KeyMap
+	styles  *color.Styles
+	width   int
+	height  int
+	err     error
+	hasData bool
 }

--- a/internal/view/offers/view.go
+++ b/internal/view/offers/view.go
@@ -39,9 +39,13 @@ func (v *View) Init() tea.Cmd { return nil }
 
 func (v *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if dataMsg, ok := msg.(OffersDataMsg); ok {
-		if dataMsg.Err == nil {
-			v.table.SetRows(Rows(dataMsg.Offers))
+		if dataMsg.Err != nil {
+			v.err = dataMsg.Err
+			return v, nil
 		}
+		v.err = nil
+		v.hasData = true
+		v.table.SetRows(Rows(dataMsg.Offers))
 		return v, nil
 	}
 
@@ -51,6 +55,15 @@ func (v *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (v *View) View() tea.View {
+	if v.err != nil {
+		return tea.NewView(v.styles.ErrorStyle.Render("Error: " + v.err.Error()))
+	}
+	if !v.hasData {
+		return tea.NewView(v.styles.MutedText.Render("Loading offers..."))
+	}
+	if len(v.table.Rows()) == 0 {
+		return tea.NewView(v.styles.MutedText.Render("No application offers found."))
+	}
 	return tea.NewView(v.table.View())
 }
 

--- a/internal/view/storage/types.go
+++ b/internal/view/storage/types.go
@@ -19,9 +19,11 @@ type StorageDataMsg struct {
 
 // View is the Bubble Tea model for the storage table view.
 type View struct {
-	table  table.Model
-	keys   ui.KeyMap
-	styles *color.Styles
-	width  int
-	height int
+	table   table.Model
+	keys    ui.KeyMap
+	styles  *color.Styles
+	width   int
+	height  int
+	err     error
+	hasData bool
 }

--- a/internal/view/storage/view.go
+++ b/internal/view/storage/view.go
@@ -41,8 +41,11 @@ func (v *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case StorageDataMsg:
 		if msg.Err != nil {
+			v.err = msg.Err
 			return v, nil
 		}
+		v.err = nil
+		v.hasData = true
 		v.table.SetRows(Rows(msg.Instances, v.styles))
 		return v, nil
 	}
@@ -52,6 +55,15 @@ func (v *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (v *View) View() tea.View {
+	if v.err != nil {
+		return tea.NewView(v.styles.ErrorStyle.Render("Error: " + v.err.Error()))
+	}
+	if !v.hasData {
+		return tea.NewView(v.styles.MutedText.Render("Loading storage..."))
+	}
+	if len(v.table.Rows()) == 0 {
+		return tea.NewView(v.styles.MutedText.Render("No storage instances found."))
+	}
 	return tea.NewView(v.table.View())
 }
 


### PR DESCRIPTION
## Summary

- Add error/empty/loading state messages to storage and offers views (matching `appconfig` pattern)
- Fix debug log search to highlight **all** occurrences per line instead of only the first
- Account for error line height in `contentHeight()` to prevent terminal scroll overflow

Closes #62