### PR TITLE
ci: gate snap publish on CI success and expand linter set

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,8 +1,10 @@
 name: Snap
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
     branches: [main]
+    types: [completed]
 
 permissions:
   contents: read
@@ -11,6 +13,7 @@ jobs:
   snap:
     name: Build and Publish Snap
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,10 @@ linters:
     - staticcheck
     - ineffassign
     - revive
+    - bodyclose
+    - errorlint
+    - noctx
+    - misspell
 
   settings:
     revive:

--- a/internal/api/mock_test.go
+++ b/internal/api/mock_test.go
@@ -156,7 +156,7 @@ func TestMockClient_ConcurrentAccess(t *testing.T) {
 			defer wg.Done()
 			err := client.ScaleApplication(context.Background(), "postgresql", 1)
 			if err != nil {
-				errors <- fmt.Errorf("concurrent scale error: %v", err)
+				errors <- fmt.Errorf("concurrent scale error: %w", err)
 			}
 		}()
 	}


### PR DESCRIPTION
## Summary

- Gate snap publish on CI success using `workflow_run` trigger instead of direct push-to-main
- Add `bodyclose`, `errorlint`, `noctx`, and `misspell` linters to golangci config
- Fix `errorlint` finding: use `%w` instead of `%v` in test error wrapping

Closes #58