### PR TITLE
fix: security hardening for HTTP client, config permissions, and credentials

### DIFF
--- a/internal/api/juju.go
+++ b/internal/api/juju.go
@@ -47,7 +47,14 @@ const (
 	// defaultDebugLogBacklog is the number of recent log lines fetched when
 	// starting a debug-log stream and no explicit backlog is configured.
 	defaultDebugLogBacklog uint = 100
+
+	// charmhubHTTPTimeout is the timeout for individual Charmhub HTTP requests.
+	charmhubHTTPTimeout = 30 * time.Second
 )
+
+// charmhubHTTPClient is a dedicated HTTP client for Charmhub requests,
+// avoiding http.DefaultClient which has no timeout.
+var charmhubHTTPClient = &http.Client{Timeout: charmhubHTTPTimeout}
 
 // nopLogger is a no-op implementation of core/logger.Logger.
 type nopLogger struct{}
@@ -170,7 +177,7 @@ func (c *JujuClient) CharmhubSuggestions(ctx context.Context, query string, limi
 	}
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := charmhubHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("querying charmhub: %w", err)
 	}
@@ -246,7 +253,7 @@ func (c *JujuClient) CharmRelationInfo(ctx context.Context, charmName string) (m
 	}
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := charmhubHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("querying charmhub info: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -319,7 +319,7 @@ func (c *Config) Save(path string) error {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
 
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("writing config file: %w", err)
 	}
 

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -34,14 +34,22 @@ func LoadAICredential(provider string) string {
 	}
 }
 
-// ghCLIToken attempts to read a GitHub token from the gh CLI config file
-// at ~/.config/gh/hosts.yml.
+// ghCLIToken attempts to read a GitHub token from the gh CLI config file.
+// It respects GH_CONFIG_DIR and XDG_CONFIG_HOME, falling back to ~/.config/gh.
 func ghCLIToken() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
+	dir := os.Getenv("GH_CONFIG_DIR")
+	if dir == "" {
+		if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+			dir = xdg + "/gh"
+		} else {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return ""
+			}
+			dir = home + "/.config/gh"
+		}
 	}
-	data, err := os.ReadFile(home + "/.config/gh/hosts.yml")
+	data, err := os.ReadFile(dir + "/hosts.yml")
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
## Summary

- Replace `http.DefaultClient` with a dedicated `charmhubHTTPClient` with 30s timeout
- Tighten config file permissions from `0644` to `0600` (user-only read/write)
- Respect `GH_CONFIG_DIR` and `XDG_CONFIG_HOME` when locating gh CLI credentials

Closes #59