### PR TITLE
feat: support action parameters in the action modal

### DIFF
--- a/internal/view/actionmodal/modal.go
+++ b/internal/view/actionmodal/modal.go
@@ -360,7 +360,7 @@ func (m *Modal) renderParams(contentW int) string {
 		if i == m.paramCursor && m.paramEdit {
 			val += "█"
 		}
-		if val == "" && !(i == m.paramCursor && m.paramEdit) {
+		if val == "" && (i != m.paramCursor || !m.paramEdit) {
 			sb.WriteString("    " + mutedStyle.Render("(empty)") + "\n")
 		} else {
 			sb.WriteString("    " + val + "\n")


### PR DESCRIPTION
## Summary

- Add `phaseParams` step between action selection and execution for actions that define parameters
- Parameters are extracted from `ActionSpec.Params` (JSON-Schema style), displayed as editable fields
- Collected parameters are passed to `RunActionRequestMsg.Params` (previously always `nil`)
- Replace hardcoded key codes (`j`/`k`) with `key.Matches` using configured key bindings

Closes #60