### PR TITLE
test: add unit tests for LLM tools, view helpers, UI chrome, offers, and storage

### DIFF
--- a/internal/llm/tools_test.go
+++ b/internal/llm/tools_test.go
@@ -1,0 +1,125 @@
+package llm
+
+import (
+	"testing"
+)
+
+func TestParseToolCall(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    *ToolCallRequest
+	}{
+		{
+			name:    "valid tool call",
+			content: `Some text <tool_call>{"tool":"get_status","args":{"model":"prod"}}</tool_call> more text`,
+			want:    &ToolCallRequest{Tool: "get_status", Args: map[string]any{"model": "prod"}},
+		},
+		{
+			name:    "tool call at start",
+			content: `<tool_call>{"tool":"list_units","args":{}}</tool_call>`,
+			want:    &ToolCallRequest{Tool: "list_units", Args: map[string]any{}},
+		},
+		{
+			name:    "no tool call",
+			content: "Hello, this is regular text.",
+			want:    nil,
+		},
+		{
+			name:    "incomplete tool call - no close tag",
+			content: `<tool_call>{"tool":"get_status","args":{}}`,
+			want:    nil,
+		},
+		{
+			name:    "invalid JSON inside tags",
+			content: `<tool_call>not json</tool_call>`,
+			want:    nil,
+		},
+		{
+			name:    "empty content",
+			content: "",
+			want:    nil,
+		},
+		{
+			name:    "tool call with whitespace",
+			content: `<tool_call>  {"tool":"scale","args":{"app":"nginx","delta":"1"}}  </tool_call>`,
+			want:    &ToolCallRequest{Tool: "scale", Args: map[string]any{"app": "nginx", "delta": "1"}},
+		},
+		{
+			name:    "only open tag",
+			content: `<tool_call>`,
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseToolCall(tt.content)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("ParseToolCall() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("ParseToolCall() = nil, want non-nil")
+			}
+			if got.Tool != tt.want.Tool {
+				t.Errorf("Tool = %q, want %q", got.Tool, tt.want.Tool)
+			}
+		})
+	}
+}
+
+func TestStripToolCall(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "strip from middle",
+			content: "Before\n<tool_call>{\"tool\":\"x\",\"args\":{}}</tool_call>\nAfter",
+			want:    "Before\nAfter",
+		},
+		{
+			name:    "strip from start",
+			content: "<tool_call>{\"tool\":\"x\",\"args\":{}}</tool_call>\nAfter",
+			want:    "After",
+		},
+		{
+			name:    "strip from end",
+			content: "Before\n<tool_call>{\"tool\":\"x\",\"args\":{}}</tool_call>",
+			want:    "Before",
+		},
+		{
+			name:    "no tool call",
+			content: "Just regular text",
+			want:    "Just regular text",
+		},
+		{
+			name:    "incomplete tool call - strip to end",
+			content: "Before\n<tool_call>partial json...",
+			want:    "Before",
+		},
+		{
+			name:    "empty string",
+			content: "",
+			want:    "",
+		},
+		{
+			name:    "entire string is tool call",
+			content: "<tool_call>{\"tool\":\"x\",\"args\":{}}</tool_call>",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripToolCall(tt.content)
+			if got != tt.want {
+				t.Errorf("StripToolCall() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/chrome_test.go
+++ b/internal/ui/chrome_test.go
@@ -1,0 +1,177 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/bschimke95/jara/internal/color"
+)
+
+func TestLogoHeight(t *testing.T) {
+	h := LogoHeight()
+	if h <= 0 {
+		t.Errorf("LogoHeight() = %d, want > 0", h)
+	}
+	// The ASCII art logo has 7 lines (1 empty + 6 character lines).
+	if h != 7 {
+		t.Errorf("LogoHeight() = %d, want 7", h)
+	}
+}
+
+func TestStatusBar(t *testing.T) {
+	s := color.DefaultStyles()
+	tests := []struct {
+		name          string
+		resourceCount int
+		resourceType  string
+		width         int
+	}{
+		{
+			name:          "basic",
+			resourceCount: 5,
+			resourceType:  "applications",
+			width:         40,
+		},
+		{
+			name:          "zero count",
+			resourceCount: 0,
+			resourceType:  "units",
+			width:         30,
+		},
+		{
+			name:          "large count",
+			resourceCount: 1000,
+			resourceType:  "machines",
+			width:         50,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StatusBar(tt.resourceCount, tt.resourceType, tt.width, s)
+			if got == "" {
+				t.Error("StatusBar() returned empty string")
+			}
+		})
+	}
+}
+
+func TestHintsForView(t *testing.T) {
+	keys := DefaultKeyMap()
+
+	tests := []struct {
+		viewName string
+		minHints int // at least this many hints expected
+	}{
+		{"Controllers", 4},  // select + 3 common
+		{"Models", 5},       // select + back + 3 common
+		{"Model", 8},        // units + relations + logs(app) + logs + scale + 3 common
+		{"Applications", 6}, // enter + logs(app) + logs + 3 common
+		{"Units", 7},        // back + logs(unit) + logs + scale + 3 common
+		{"Machines", 6},     // back + logs(machine) + logs + 3 common
+		{"Relations", 5},    // back + logs + 3 common
+		{"Debug Log", 10},   // back + bottom + top + filter + clear + search + next/prev + 3 common
+		{"Unknown View", 5}, // select + back + 3 common (default case)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.viewName, func(t *testing.T) {
+			hints := HintsForView(tt.viewName, keys)
+			if len(hints) < tt.minHints {
+				t.Errorf("HintsForView(%q) returned %d hints, want >= %d", tt.viewName, len(hints), tt.minHints)
+			}
+
+			// Every hint should have non-empty Key and Desc.
+			for i, h := range hints {
+				if h.Key == "" {
+					t.Errorf("hint[%d].Key is empty for view %q", i, tt.viewName)
+				}
+				if h.Desc == "" {
+					t.Errorf("hint[%d].Desc is empty for view %q", i, tt.viewName)
+				}
+			}
+		})
+	}
+}
+
+func TestCrumbBar(t *testing.T) {
+	s := color.DefaultStyles()
+
+	tests := []struct {
+		name   string
+		crumbs []string
+		width  int
+	}{
+		{
+			name:   "empty crumbs",
+			crumbs: nil,
+			width:  80,
+		},
+		{
+			name:   "single crumb",
+			crumbs: []string{"Controllers"},
+			width:  80,
+		},
+		{
+			name:   "multiple crumbs",
+			crumbs: []string{"Controllers", "Models", "Applications"},
+			width:  120,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CrumbBar(tt.crumbs, tt.width, s)
+			// Should not panic, should return a string.
+			if tt.crumbs == nil && got == "" {
+				// Empty crumbs returning empty-ish is acceptable.
+				return
+			}
+			if got == "" && len(tt.crumbs) > 0 {
+				t.Error("CrumbBar() returned empty string for non-empty crumbs")
+			}
+		})
+	}
+}
+
+func TestFooter(t *testing.T) {
+	s := color.DefaultStyles()
+
+	tests := []struct {
+		name       string
+		hints      []KeyHint
+		filterText string
+		width      int
+	}{
+		{
+			name:       "no hints no filter",
+			hints:      nil,
+			filterText: "",
+			width:      80,
+		},
+		{
+			name: "hints only",
+			hints: []KeyHint{
+				{Key: "q", Desc: "quit"},
+				{Key: "?", Desc: "help"},
+			},
+			filterText: "",
+			width:      80,
+		},
+		{
+			name: "hints with filter",
+			hints: []KeyHint{
+				{Key: "q", Desc: "quit"},
+			},
+			filterText: "mysql",
+			width:      80,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Footer(tt.hints, tt.filterText, tt.width, s)
+			// Should not panic.
+			_ = got
+		})
+	}
+}

--- a/internal/view/offers/rows_test.go
+++ b/internal/view/offers/rows_test.go
@@ -1,0 +1,114 @@
+package offers
+
+import (
+	"testing"
+
+	"github.com/bschimke95/jara/internal/model"
+)
+
+func TestColumns(t *testing.T) {
+	cols := Columns()
+	if len(cols) != 5 {
+		t.Fatalf("Columns() returned %d columns, want 5", len(cols))
+	}
+
+	want := []string{"Offer", "Application", "URL", "Endpoints", "Connections"}
+	for i, c := range cols {
+		if c.Title != want[i] {
+			t.Errorf("Columns()[%d].Title = %q, want %q", i, c.Title, want[i])
+		}
+		if c.Width <= 0 {
+			t.Errorf("Columns()[%d].Width = %d, want > 0", i, c.Width)
+		}
+	}
+}
+
+func TestRows(t *testing.T) {
+	tests := []struct {
+		name   string
+		offers []model.Offer
+		want   [][]string // expected row values
+	}{
+		{
+			name:   "empty slice",
+			offers: nil,
+			want:   nil,
+		},
+		{
+			name: "single offer no endpoints",
+			offers: []model.Offer{
+				{
+					Name:            "my-offer",
+					ApplicationName: "mysql",
+					OfferURL:        "admin/prod.mysql",
+					Endpoints:       nil,
+					ActiveConnCount: 0,
+					TotalConnCount:  0,
+				},
+			},
+			want: [][]string{
+				{"my-offer", "mysql", "admin/prod.mysql", "", "0/0"},
+			},
+		},
+		{
+			name: "single offer with endpoints",
+			offers: []model.Offer{
+				{
+					Name:            "db-offer",
+					ApplicationName: "postgresql",
+					OfferURL:        "admin/staging.postgresql",
+					Endpoints:       []string{"db", "db-admin"},
+					ActiveConnCount: 3,
+					TotalConnCount:  5,
+				},
+			},
+			want: [][]string{
+				{"db-offer", "postgresql", "admin/staging.postgresql", "db, db-admin", "3/5"},
+			},
+		},
+		{
+			name: "multiple offers",
+			offers: []model.Offer{
+				{
+					Name:            "offer-a",
+					ApplicationName: "app-a",
+					OfferURL:        "url-a",
+					Endpoints:       []string{"ep1"},
+					ActiveConnCount: 1,
+					TotalConnCount:  2,
+				},
+				{
+					Name:            "offer-b",
+					ApplicationName: "app-b",
+					OfferURL:        "url-b",
+					Endpoints:       []string{"ep1", "ep2", "ep3"},
+					ActiveConnCount: 10,
+					TotalConnCount:  20,
+				},
+			},
+			want: [][]string{
+				{"offer-a", "app-a", "url-a", "ep1", "1/2"},
+				{"offer-b", "app-b", "url-b", "ep1, ep2, ep3", "10/20"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows := Rows(tt.offers)
+			if len(rows) != len(tt.want) {
+				t.Fatalf("Rows() returned %d rows, want %d", len(rows), len(tt.want))
+			}
+			for i, row := range rows {
+				if len(row) != 5 {
+					t.Fatalf("row[%d] has %d columns, want 5", i, len(row))
+				}
+				for j, cell := range row {
+					if cell != tt.want[i][j] {
+						t.Errorf("row[%d][%d] = %q, want %q", i, j, cell, tt.want[i][j])
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/view/storage/rows_test.go
+++ b/internal/view/storage/rows_test.go
@@ -1,0 +1,126 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/bschimke95/jara/internal/color"
+	"github.com/bschimke95/jara/internal/model"
+)
+
+func TestColumns(t *testing.T) {
+	cols := Columns()
+	if len(cols) != 6 {
+		t.Fatalf("Columns() returned %d columns, want 6", len(cols))
+	}
+
+	want := []string{"ID", "Kind", "Owner", "Status", "Persistent", "Pool/Location"}
+	for i, c := range cols {
+		if c.Title != want[i] {
+			t.Errorf("Columns()[%d].Title = %q, want %q", i, c.Title, want[i])
+		}
+		if c.Width <= 0 {
+			t.Errorf("Columns()[%d].Width = %d, want > 0", i, c.Width)
+		}
+	}
+}
+
+func TestRows(t *testing.T) {
+	styles := color.DefaultStyles()
+
+	tests := []struct {
+		name      string
+		instances []model.StorageInstance
+		wantLen   int
+		// Check specific cell values by [row][col] for non-styled fields.
+		// Styled fields (Status) are checked separately.
+		checkCells map[[2]int]string
+	}{
+		{
+			name:      "empty slice",
+			instances: nil,
+			wantLen:   0,
+		},
+		{
+			name: "single instance persistent",
+			instances: []model.StorageInstance{
+				{
+					ID:         "data/0",
+					Kind:       "filesystem",
+					Owner:      "mysql/0",
+					Status:     "attached",
+					Persistent: true,
+					Pool:       "rootfs",
+				},
+			},
+			wantLen: 1,
+			checkCells: map[[2]int]string{
+				{0, 0}: "data/0",
+				{0, 1}: "filesystem",
+				{0, 2}: "mysql/0",
+				// col 3 is styled status — skip exact match
+				{0, 4}: "yes",
+				{0, 5}: "rootfs",
+			},
+		},
+		{
+			name: "single instance not persistent",
+			instances: []model.StorageInstance{
+				{
+					ID:         "logs/1",
+					Kind:       "block",
+					Owner:      "app/1",
+					Status:     "detaching",
+					Persistent: false,
+					Pool:       "ebs",
+				},
+			},
+			wantLen: 1,
+			checkCells: map[[2]int]string{
+				{0, 0}: "logs/1",
+				{0, 1}: "block",
+				{0, 2}: "app/1",
+				{0, 4}: "no",
+				{0, 5}: "ebs",
+			},
+		},
+		{
+			name: "multiple instances",
+			instances: []model.StorageInstance{
+				{ID: "a/0", Kind: "filesystem", Owner: "x/0", Status: "attached", Persistent: true, Pool: "p1"},
+				{ID: "b/1", Kind: "block", Owner: "y/1", Status: "error", Persistent: false, Pool: "p2"},
+			},
+			wantLen: 2,
+			checkCells: map[[2]int]string{
+				{0, 0}: "a/0",
+				{0, 4}: "yes",
+				{1, 0}: "b/1",
+				{1, 4}: "no",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows := Rows(tt.instances, styles)
+			if len(rows) != tt.wantLen {
+				t.Fatalf("Rows() returned %d rows, want %d", len(rows), tt.wantLen)
+			}
+			for pos, want := range tt.checkCells {
+				r, c := pos[0], pos[1]
+				if r >= len(rows) || c >= len(rows[r]) {
+					t.Errorf("cell [%d][%d] out of bounds", r, c)
+					continue
+				}
+				if rows[r][c] != want {
+					t.Errorf("row[%d][%d] = %q, want %q", r, c, rows[r][c], want)
+				}
+			}
+			// Verify each row has exactly 6 columns.
+			for i, row := range rows {
+				if len(row) != 6 {
+					t.Errorf("row[%d] has %d columns, want 6", i, len(row))
+				}
+			}
+		})
+	}
+}

--- a/internal/view/view_test.go
+++ b/internal/view/view_test.go
@@ -1,0 +1,142 @@
+package view
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/key"
+)
+
+func TestBindingKey(t *testing.T) {
+	tests := []struct {
+		name string
+		b    key.Binding
+		want string
+	}{
+		{
+			name: "simple key",
+			b:    key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit")),
+			want: "q",
+		},
+		{
+			name: "multi-key uses first help text",
+			b:    key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("k/up", "up")),
+			want: "k/up",
+		},
+		{
+			name: "special key",
+			b:    key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+			want: "enter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BindingKey(tt.b)
+			if got != tt.want {
+				t.Errorf("BindingKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPadToHeight(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		height  int
+		want    int // expected number of lines
+	}{
+		{
+			name:    "pad empty to 5",
+			content: "",
+			height:  5,
+			want:    5,
+		},
+		{
+			name:    "content already exact",
+			content: "a\nb\nc",
+			height:  3,
+			want:    3,
+		},
+		{
+			name:    "content shorter than height",
+			content: "line1\nline2",
+			height:  5,
+			want:    5,
+		},
+		{
+			name:    "content taller than height - truncate",
+			content: "a\nb\nc\nd\ne",
+			height:  3,
+			want:    3,
+		},
+		{
+			name:    "height zero",
+			content: "a\nb",
+			height:  0,
+			want:    0,
+		},
+		{
+			name:    "single line padded",
+			content: "only one line",
+			height:  3,
+			want:    3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PadToHeight(tt.content, tt.height)
+
+			var gotLines int
+			if tt.height == 0 {
+				// PadToHeight with height=0 returns "" (truncated to 0 lines)
+				if got != "" {
+					t.Errorf("PadToHeight() = %q, want empty", got)
+				}
+				return
+			}
+
+			gotLines = len(strings.Split(got, "\n"))
+			if gotLines != tt.want {
+				t.Errorf("PadToHeight() produced %d lines, want %d", gotLines, tt.want)
+			}
+		})
+	}
+}
+
+func TestPadToHeight_preservesContent(t *testing.T) {
+	content := "hello\nworld"
+	got := PadToHeight(content, 5)
+	lines := strings.Split(got, "\n")
+
+	if lines[0] != "hello" {
+		t.Errorf("first line = %q, want %q", lines[0], "hello")
+	}
+	if lines[1] != "world" {
+		t.Errorf("second line = %q, want %q", lines[1], "world")
+	}
+	// Padded lines should be empty.
+	for i := 2; i < 5; i++ {
+		if lines[i] != "" {
+			t.Errorf("padded line[%d] = %q, want empty", i, lines[i])
+		}
+	}
+}
+
+func TestPadToHeight_truncatesContent(t *testing.T) {
+	content := "a\nb\nc\nd\ne"
+	got := PadToHeight(content, 2)
+	lines := strings.Split(got, "\n")
+
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2", len(lines))
+	}
+	if lines[0] != "a" {
+		t.Errorf("line[0] = %q, want %q", lines[0], "a")
+	}
+	if lines[1] != "b" {
+		t.Errorf("line[1] = %q, want %q", lines[1], "b")
+	}
+}


### PR DESCRIPTION
## Summary

- Add test coverage for 5 packages that previously had zero or minimal test files
- Tests cover pure/utility functions that don't require complex mocking (data transformation, string formatting, layout calculations)

### New test files:
- `internal/llm/tools_test.go` — `ParseToolCall` and `StripToolCall` with 15 edge-case scenarios
- `internal/view/view_test.go` — `PadToHeight` (padding, truncation, content preservation) and `BindingKey`
- `internal/view/offers/rows_test.go` — `Columns` and `Rows` data transformation
- `internal/view/storage/rows_test.go` — `Columns` and `Rows` with persistent flag rendering
- `internal/ui/chrome_test.go` — `LogoHeight`, `StatusBar`, `HintsForView` (all 9 view cases), `CrumbBar`, `Footer`

Total: 44 new test cases across 5 files.

Closes #56