### PR TITLE
fix: pre-install ffmpeg and build jara before VHS demo generation

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -22,10 +22,17 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install ffmpeg
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg
+
+      - name: Build jara
+        run: make build-vhs
+
       - name: Generate demo GIF
         uses: charmbracelet/vhs-action@v2
         with:
           path: tests/vhs/demo.tape
+          install-fonts: true
         env:
           JARA_ROOT: ${{ github.workspace }}
 


### PR DESCRIPTION
## Summary

- Pre-install ffmpeg via apt before VHS action runs (the action's built-in ffmpeg installer fails on ubuntu-latest)
- Build jara binary (`make build-vhs`) before running the demo tape (the tape executes `./jara --demo`)
- Enable `install-fonts: true` for consistent rendering

Fixes the demo workflow failure: https://github.com/bschimke95/jara/actions/runs/24228488281/job/70734841598