### PR TITLE
Rename personal-files plugs to follow store naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@
 
 ```
 sudo snap install jara
-snap connect jara:dot-jara
-snap connect jara:dot-local-share-juju
-snap connect jara:dot-config-juju
 ```
 
 ### From source

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@
 
 ```
 sudo snap install jara
-snap connect jara:juju-client-observe
-snap connect jara:jara-config
+snap connect jara:dot-jara
+snap connect jara:dot-local-share-juju
+snap connect jara:dot-config-juju
 ```
 
 ### From source

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,8 +10,9 @@ description: |
 
   To connect to your Juju client configuration after installation, run:
 
-    snap connect jara:juju-client-observe
-    snap connect jara:jara-config
+    snap connect jara:dot-jara
+    snap connect jara:dot-local-share-juju
+    snap connect jara:dot-config-juju
 
 grade: devel
 confinement: strict
@@ -27,23 +28,23 @@ apps:
       - home
       - network
       - network-bind
-      - juju-client-observe
-      - jara-config
+       - dot-jara
+      - dot-local-share-juju
+      - dot-config-juju
 
 plugs:
-  juju-client-observe:
+  dot-jara:
+    interface: personal-files
+    write:
+      - $HOME/.jara
+  dot-local-share-juju:
+    interface: personal-files
+    write:
+      - $HOME/.local/share/juju
+  dot-config-juju:
     interface: personal-files
     read:
-      - $HOME/.local/share/juju
       - $HOME/.config/juju
-    write:
-      - $HOME/.local/share/juju
-  jara-config:
-    interface: personal-files
-    read:
-      - $HOME/.jara
-    write:
-      - $HOME/.jara
 
 parts:
   copilot-cli:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,12 +8,6 @@ description: |
   controllers, models, applications, units, machines, and relations without
   leaving the terminal.
 
-  To connect to your Juju client configuration after installation, run:
-
-    snap connect jara:dot-jara
-    snap connect jara:dot-local-share-juju
-    snap connect jara:dot-config-juju
-
 grade: devel
 confinement: strict
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ apps:
       - home
       - network
       - network-bind
-       - dot-jara
+      - dot-jara
       - dot-local-share-juju
       - dot-config-juju
 


### PR DESCRIPTION
## Summary

- Rename personal-files plugs to use the dot-prefixed naming convention required for store auto-connection approval
- Split `juju-client-observe` into separate `dot-local-share-juju` (write) and `dot-config-juju` (read) plugs
- Rename `jara-config` to `dot-jara`

Ref: [Snapcraft store review request for personal-files auto-connection.](https://forum.snapcraft.io/t/privileged-interfaces-auto-connection-request-jara/50989/4)