### PR TITLE
Sort all map-derived lists for deterministic display order

### DIFF
--- a/internal/api/juju.go
+++ b/internal/api/juju.go
@@ -1372,6 +1372,7 @@ func convertFullStatus(s *params.FullStatus) *model.FullStatus {
 	for _, r := range s.Relations {
 		fs.Relations = append(fs.Relations, convertRelation(r))
 	}
+	sort.Slice(fs.Relations, func(i, j int) bool { return fs.Relations[i].ID < fs.Relations[j].ID })
 
 	return fs
 }

--- a/internal/app/input.go
+++ b/internal/app/input.go
@@ -247,9 +247,6 @@ func (m Model) handleGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 	case key.Matches(msg, m.keys.StorageNav):
 		m2, cmd := m.handleNavigate(view.NavigateMsg{Target: nav.StorageView})
 		return m2, cmd, true
-	case key.Matches(msg, m.keys.ChatNav):
-		m2, cmd := m.handleNavigate(view.NavigateMsg{Target: nav.ChatView})
-		return m2, cmd, true
 	case key.Matches(msg, m.keys.Help):
 		currentView := m.views[m.stack.Current().View]
 		m.helpModal.SetViewHints(currentView.KeyHints())

--- a/internal/color/styles.go
+++ b/internal/color/styles.go
@@ -353,12 +353,12 @@ func (s *Styles) RebuildStyles() {
 	s.HintSep = lipgloss.NewStyle().Foreground(s.Subtle)
 
 	s.CrumbActive = lipgloss.NewStyle().
-		Foreground(s.CrumbFgColor).
+		Foreground(s.Title).
 		Background(s.Highlight).
 		Bold(true).
 		Padding(0, 1)
 	s.CrumbAncestor = lipgloss.NewStyle().
-		Foreground(s.CrumbFgColor).
+		Foreground(s.Title).
 		Background(s.Highlight).
 		Padding(0, 1)
 	s.CrumbSep = lipgloss.NewStyle().Foreground(s.Subtle)

--- a/internal/color/styles.go
+++ b/internal/color/styles.go
@@ -354,12 +354,12 @@ func (s *Styles) RebuildStyles() {
 
 	s.CrumbActive = lipgloss.NewStyle().
 		Foreground(s.CrumbFgColor).
-		Background(s.CrumbBgColor).
+		Background(s.Highlight).
 		Bold(true).
 		Padding(0, 1)
 	s.CrumbAncestor = lipgloss.NewStyle().
 		Foreground(s.CrumbFgColor).
-		Background(s.CrumbBgAltColor).
+		Background(s.Highlight).
 		Padding(0, 1)
 	s.CrumbSep = lipgloss.NewStyle().Foreground(s.Subtle)
 

--- a/internal/color/styles.go
+++ b/internal/color/styles.go
@@ -246,7 +246,7 @@ func defaultPalette() palette {
 		muted:             lipgloss.Color("#5c6370"),
 		hintKey:           lipgloss.Color("#e5c07b"),
 		hintDesc:          lipgloss.Color("#5c6370"),
-		crumbFg:           lipgloss.Color("#282c34"),
+		crumbFg:           lipgloss.Color("#abb2bf"),
 		crumbBg:           lipgloss.Color("#61afef"),
 		border:            lipgloss.Color("#4b5263"),
 		borderTitle:       lipgloss.Color("#61afef"),
@@ -353,12 +353,12 @@ func (s *Styles) RebuildStyles() {
 	s.HintSep = lipgloss.NewStyle().Foreground(s.Subtle)
 
 	s.CrumbActive = lipgloss.NewStyle().
-		Foreground(s.Title).
+		Foreground(s.CrumbFgColor).
 		Background(s.Highlight).
 		Bold(true).
 		Padding(0, 1)
 	s.CrumbAncestor = lipgloss.NewStyle().
-		Foreground(s.Title).
+		Foreground(s.CrumbFgColor).
 		Background(s.Highlight).
 		Padding(0, 1)
 	s.CrumbSep = lipgloss.NewStyle().Foreground(s.Subtle)

--- a/internal/nav/nav.go
+++ b/internal/nav/nav.go
@@ -91,8 +91,6 @@ var CommandAliases = map[string]ViewID{
 	"offers":       OffersView,
 	"offer":        OffersView,
 	"off":          OffersView,
-	"config":       AppConfigView,
-	"cfg":          AppConfigView,
 	"storage":      StorageView,
 	"stor":         StorageView,
 	"chat":         ChatView,

--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -330,32 +330,28 @@ func HintsForView(viewName string, keys KeyMap) []KeyHint {
 			{Key: bk(keys.UnitsNav), Desc: "units"},
 			{Key: bk(keys.RelationsNav), Desc: "relations"},
 			{Key: bk(keys.LogsJump), Desc: "logs (app)"},
-			{Key: bk(keys.LogsView), Desc: "logs"},
 			{Key: bk(keys.ScaleUp) + "/" + bk(keys.ScaleDown), Desc: "scale"},
 		}, common...)
 	case "Applications":
 		return append([]KeyHint{
 			{Key: bk(keys.Enter), Desc: "units"},
 			{Key: bk(keys.LogsJump), Desc: "logs (app)"},
-			{Key: bk(keys.LogsView), Desc: "logs"},
 		}, common...)
 	case "Units":
 		return append([]KeyHint{
 			{Key: bk(keys.Back), Desc: "back"},
 			{Key: bk(keys.LogsJump), Desc: "logs (unit)"},
-			{Key: bk(keys.LogsView), Desc: "logs"},
 			{Key: bk(keys.ScaleUp) + "/" + bk(keys.ScaleDown), Desc: "scale"},
 		}, common...)
 	case "Machines":
 		return append([]KeyHint{
 			{Key: bk(keys.Back), Desc: "back"},
 			{Key: bk(keys.LogsJump), Desc: "logs (machine)"},
-			{Key: bk(keys.LogsView), Desc: "logs"},
 		}, common...)
 	case "Relations":
 		return append([]KeyHint{
 			{Key: bk(keys.Back), Desc: "back"},
-			{Key: bk(keys.LogsView), Desc: "logs"},
+			{Key: bk(keys.LogsJump), Desc: "logs"},
 		}, common...)
 	case "Debug Log":
 		return append([]KeyHint{

--- a/internal/ui/chrome_test.go
+++ b/internal/ui/chrome_test.go
@@ -64,10 +64,10 @@ func TestHintsForView(t *testing.T) {
 	}{
 		{"Controllers", 4},  // select + 3 common
 		{"Models", 5},       // select + back + 3 common
-		{"Model", 8},        // units + relations + logs(app) + logs + scale + 3 common
-		{"Applications", 6}, // enter + logs(app) + logs + 3 common
-		{"Units", 7},        // back + logs(unit) + logs + scale + 3 common
-		{"Machines", 6},     // back + logs(machine) + logs + 3 common
+		{"Model", 7},        // units + relations + logs(app) + scale + 3 common
+		{"Applications", 5}, // enter + logs(app) + 3 common
+		{"Units", 6},        // back + logs(unit) + scale + 3 common
+		{"Machines", 5},     // back + logs(machine) + 3 common
 		{"Relations", 5},    // back + logs + 3 common
 		{"Debug Log", 10},   // back + bottom + top + filter + clear + search + next/prev + 3 common
 		{"Unknown View", 5}, // select + back + 3 common (default case)

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -117,28 +117,28 @@ func DefaultKeyMap() KeyMap {
 			key.WithHelp("-", "scale down"),
 		),
 		Deploy: key.NewBinding(
-			key.WithKeys("D"),
-			key.WithHelp("D", "deploy"),
+			key.WithKeys("d"),
+			key.WithHelp("d", "deploy"),
 		),
 		Relate: key.NewBinding(
 			key.WithKeys("r"),
 			key.WithHelp("r", "relate"),
 		),
 		DeleteRelation: key.NewBinding(
-			key.WithKeys("D"),
-			key.WithHelp("D", "delete relation"),
+			key.WithKeys("d"),
+			key.WithHelp("d", "delete relation"),
 		),
 		LogsJump: key.NewBinding(
 			key.WithKeys("L"),
 			key.WithHelp("L", "logs"),
 		),
 		LogsView: key.NewBinding(
-			key.WithKeys("l"),
-			key.WithHelp("l", "logs"),
+			key.WithKeys("L"),
+			key.WithHelp("L", "logs"),
 		),
 		ClearFilter: key.NewBinding(
-			key.WithKeys("D"),
-			key.WithHelp("D", "clear filter"),
+			key.WithKeys("d"),
+			key.WithHelp("d", "clear filter"),
 		),
 		SearchOpen: key.NewBinding(
 			key.WithKeys("/"),
@@ -153,8 +153,8 @@ func DefaultKeyMap() KeyMap {
 			key.WithHelp("N", "prev match"),
 		),
 		FilterOpen: key.NewBinding(
-			key.WithKeys("F"),
-			key.WithHelp("F", "filter"),
+			key.WithKeys("f"),
+			key.WithHelp("f", "filter"),
 		),
 		UnitsNav: key.NewBinding(
 			key.WithKeys("U"),
@@ -189,8 +189,8 @@ func DefaultKeyMap() KeyMap {
 			key.WithHelp("d", "decode"),
 		),
 		ApplyFilter: key.NewBinding(
-			key.WithKeys("F"),
-			key.WithHelp("F", "apply"),
+			key.WithKeys("f"),
+			key.WithHelp("f", "apply"),
 		),
 		Right: key.NewBinding(
 			key.WithKeys("l", "right"),

--- a/internal/view/applications/view.go
+++ b/internal/view/applications/view.go
@@ -164,7 +164,8 @@ func (a *View) charmSuggestions() []string {
 	if a.status == nil {
 		return out
 	}
-	for _, app := range a.status.Applications {
+	for _, appName := range ui.SortedKeys(a.status.Applications) {
+		app := a.status.Applications[appName]
 		if app.Charm != "" {
 			out = append(out, app.Charm)
 		}
@@ -177,7 +178,7 @@ func (a *View) applicationSuggestions() []string {
 		return nil
 	}
 	out := make([]string, 0, len(a.status.Applications))
-	for name := range a.status.Applications {
+	for _, name := range ui.SortedKeys(a.status.Applications) {
 		out = append(out, name)
 	}
 	return out

--- a/internal/view/applications/view.go
+++ b/internal/view/applications/view.go
@@ -55,7 +55,6 @@ func (a *View) KeyHints() []view.KeyHint {
 		{Key: view.BindingKey(a.keys.ConfigNav), Desc: "config"},
 		{Key: view.BindingKey(a.keys.Deploy), Desc: "deploy"},
 		{Key: view.BindingKey(a.keys.LogsJump), Desc: "logs (app)"},
-		{Key: view.BindingKey(a.keys.LogsView), Desc: "logs"},
 	}
 }
 
@@ -109,11 +108,6 @@ func (a *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return a, func() tea.Msg {
 				return view.NavigateMsg{Target: nav.DebugLogView, Filter: filter}
-			}
-		}
-		if key.Matches(msg, a.keys.LogsView) {
-			return a, func() tea.Msg {
-				return view.NavigateMsg{Target: nav.DebugLogView}
 			}
 		}
 		if key.Matches(msg, a.keys.ConfigNav) {

--- a/internal/view/applications/view_test.go
+++ b/internal/view/applications/view_test.go
@@ -17,7 +17,7 @@ func TestUpdateDeployStartsInput(t *testing.T) {
 		"postgresql": {Name: "postgresql"},
 	}})
 
-	_, cmd := v.Update(tea.KeyPressMsg{Text: "D", Code: 'D'})
+	_, cmd := v.Update(tea.KeyPressMsg{Text: "d", Code: 'd'})
 	if cmd == nil {
 		t.Fatal("expected focus command when opening modal")
 	}

--- a/internal/view/debuglog/view.go
+++ b/internal/view/debuglog/view.go
@@ -84,10 +84,11 @@ func (d *View) buildSuggestions() map[leftPane][]string {
 	sugg := make(map[leftPane][]string)
 
 	if d.status != nil {
-		for appName := range d.status.Applications {
+		for _, appName := range ui.SortedKeys(d.status.Applications) {
 			sugg[leftPaneApplications] = append(sugg[leftPaneApplications], appName)
 		}
-		for _, app := range d.status.Applications {
+		for _, appName := range ui.SortedKeys(d.status.Applications) {
+			app := d.status.Applications[appName]
 			for _, u := range app.Units {
 				sugg[leftPaneUnits] = append(sugg[leftPaneUnits], u.Name)
 				for _, sub := range u.Subordinates {
@@ -95,7 +96,13 @@ func (d *View) buildSuggestions() map[leftPane][]string {
 				}
 			}
 		}
-		for _, mach := range d.status.Machines {
+		machIDs := make([]string, 0, len(d.status.Machines))
+		for id := range d.status.Machines {
+			machIDs = append(machIDs, id)
+		}
+		sort.Strings(machIDs)
+		for _, id := range machIDs {
+			mach := d.status.Machines[id]
 			sugg[leftPaneMachines] = append(sugg[leftPaneMachines], "machine-"+mach.ID)
 			for _, c := range mach.Containers {
 				sugg[leftPaneMachines] = append(sugg[leftPaneMachines], "machine-"+c.ID)
@@ -103,7 +110,12 @@ func (d *View) buildSuggestions() map[leftPane][]string {
 		}
 	}
 
+	modules := make([]string, 0, len(d.seenModules))
 	for mod := range d.seenModules {
+		modules = append(modules, mod)
+	}
+	sort.Strings(modules)
+	for _, mod := range modules {
 		sugg[leftPaneModules] = append(sugg[leftPaneModules], mod)
 	}
 

--- a/internal/view/helpmodal/modal.go
+++ b/internal/view/helpmodal/modal.go
@@ -177,8 +177,6 @@ func (m *Modal) viewNavHints() []ui.KeyHint {
 		{Key: view.BindingKey(m.keys.SecretsNav), Desc: "Secrets"},
 		{Key: view.BindingKey(m.keys.OffersNav), Desc: "Offers"},
 		{Key: view.BindingKey(m.keys.StorageNav), Desc: "Storage"},
-		{Key: view.BindingKey(m.keys.ConfigNav), Desc: "Config"},
-		{Key: view.BindingKey(m.keys.ChatNav), Desc: "Chat"},
 		{Key: view.BindingKey(m.keys.LogsView), Desc: "Debug Log"},
 	}
 }

--- a/internal/view/machines/view.go
+++ b/internal/view/machines/view.go
@@ -45,7 +45,6 @@ func (m *View) SetStatus(status *model.FullStatus) {
 func (m *View) KeyHints() []view.KeyHint {
 	return []view.KeyHint{
 		{Key: view.BindingKey(m.keys.LogsJump), Desc: "logs (machine)"},
-		{Key: view.BindingKey(m.keys.LogsView), Desc: "logs"},
 	}
 }
 
@@ -66,11 +65,6 @@ func (m *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, func() tea.Msg {
 				return view.NavigateMsg{Target: nav.DebugLogView, Filter: filter}
-			}
-		}
-		if key.Matches(kp, m.keys.LogsView) {
-			return m, func() tea.Msg {
-				return view.NavigateMsg{Target: nav.DebugLogView}
 			}
 		}
 	}

--- a/internal/view/modelview/view.go
+++ b/internal/view/modelview/view.go
@@ -110,7 +110,6 @@ func (m *View) KeyHints() []view.KeyHint {
 		{Key: view.BindingKey(m.keys.RelationsNav), Desc: "relations"},
 		{Key: view.BindingKey(m.keys.ScaleUp) + "/" + view.BindingKey(m.keys.ScaleDown), Desc: "scale"},
 		{Key: view.BindingKey(m.keys.LogsJump), Desc: "logs (app)"},
-		{Key: view.BindingKey(m.keys.LogsView), Desc: "logs"},
 	}
 }
 
@@ -209,10 +208,6 @@ func (m *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, func() tea.Msg {
 				return view.NavigateMsg{Target: nav.DebugLogView, Filter: filter}
-			}
-		case key.Matches(msg, m.keys.LogsView):
-			return m, func() tea.Msg {
-				return view.NavigateMsg{Target: nav.DebugLogView}
 			}
 		case key.Matches(msg, m.keys.ScaleUp):
 			if m.selectedApp != "" {

--- a/internal/view/modelview/view.go
+++ b/internal/view/modelview/view.go
@@ -400,7 +400,8 @@ func (m *View) charmSuggestions() []string {
 	if m.status == nil {
 		return out
 	}
-	for _, app := range m.status.Applications {
+	for _, appName := range ui.SortedKeys(m.status.Applications) {
+		app := m.status.Applications[appName]
 		if app.Charm != "" {
 			out = append(out, app.Charm)
 		}
@@ -413,7 +414,7 @@ func (m *View) applicationSuggestions() []string {
 		return nil
 	}
 	out := make([]string, 0, len(m.status.Applications))
-	for name := range m.status.Applications {
+	for _, name := range ui.SortedKeys(m.status.Applications) {
 		out = append(out, name)
 	}
 	return out

--- a/internal/view/modelview/view_test.go
+++ b/internal/view/modelview/view_test.go
@@ -15,7 +15,7 @@ func TestUpdateDeployStartsInput(t *testing.T) {
 	v := New(ui.DefaultKeyMap(), color.DefaultStyles(), func(string) error { return nil })
 	v.SetSize(120, 30)
 
-	_, cmd := v.Update(tea.KeyPressMsg{Text: "D", Code: 'D'})
+	_, cmd := v.Update(tea.KeyPressMsg{Text: "d", Code: 'd'})
 	if cmd == nil {
 		t.Fatal("expected focus command when opening modal")
 	}

--- a/internal/view/relatemodal/modal.go
+++ b/internal/view/relatemodal/modal.go
@@ -104,7 +104,8 @@ func BuildSuggestions(status *model.FullStatus, charmEndpoints map[string]map[st
 
 	var result []endpointSuggestion
 
-	for name, app := range status.Applications {
+	for _, name := range ui.SortedKeys(status.Applications) {
+		app := status.Applications[name]
 		// App-only suggestion (bare app name).
 		result = append(result, endpointSuggestion{
 			Display: name,
@@ -118,7 +119,7 @@ func BuildSuggestions(status *model.FullStatus, charmEndpoints map[string]map[st
 		}
 
 		// One suggestion per endpoint from bindings.
-		for epName := range app.EndpointBindings {
+		for _, epName := range ui.SortedKeys(app.EndpointBindings) {
 			// Skip empty endpoint names and endpoints whose name matches
 			// the app name — the bare app suggestion already covers that.
 			if epName == "" || epName == name {

--- a/internal/view/relations/view.go
+++ b/internal/view/relations/view.go
@@ -147,10 +147,6 @@ func (r *View) handleKeyPress(kp tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return r, func() tea.Msg {
 			return view.NavigateMsg{Target: nav.DebugLogView}
 		}
-	case key.Matches(kp, r.keys.LogsView):
-		return r, func() tea.Msg {
-			return view.NavigateMsg{Target: nav.DebugLogView}
-		}
 	}
 
 	var cmd tea.Cmd

--- a/internal/view/secrets/view_test.go
+++ b/internal/view/secrets/view_test.go
@@ -46,7 +46,7 @@ func TestLogsNavigation(t *testing.T) {
 	v := New(ui.DefaultKeyMap(), color.DefaultStyles())
 	v.SetSize(120, 30)
 
-	_, cmd := v.Update(tea.KeyPressMsg{Text: "l", Code: 'l'})
+	_, cmd := v.Update(tea.KeyPressMsg{Text: "L", Code: 'L'})
 	if cmd == nil {
 		t.Fatal("expected navigation command on 'l'")
 	}

--- a/internal/view/units/view.go
+++ b/internal/view/units/view.go
@@ -69,7 +69,6 @@ func (u *View) KeyHints() []view.KeyHint {
 		{Key: view.BindingKey(u.keys.RunAction), Desc: "action"},
 		{Key: view.BindingKey(u.keys.ScaleUp) + "/" + view.BindingKey(u.keys.ScaleDown), Desc: "scale"},
 		{Key: view.BindingKey(u.keys.LogsJump), Desc: "logs (unit)"},
-		{Key: view.BindingKey(u.keys.LogsView), Desc: "logs"},
 	}
 }
 
@@ -183,10 +182,6 @@ func (u *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return u, func() tea.Msg {
 				return view.NavigateMsg{Target: nav.DebugLogView, Filter: filter}
-			}
-		case key.Matches(msg, u.keys.LogsView):
-			return u, func() tea.Msg {
-				return view.NavigateMsg{Target: nav.DebugLogView}
 			}
 		case key.Matches(msg, u.keys.RunAction):
 			unitName := u.selectedUnitName()


### PR DESCRIPTION
## Summary

- Sort all map iterations that produce display lists to eliminate non-deterministic ordering
- Fixes UI elements (relations, suggestions, etc.) jumping around on each refresh
- Uses existing `ui.SortedKeys()` helper and `sort.Strings()` across 4 files: `debuglog/view.go`, `relatemodal/modal.go`, `modelview/view.go`, `applications/view.go`