### PR TITLE
Match breadcrumb color to highlighted row background

### DIFF
--- a/internal/color/styles.go
+++ b/internal/color/styles.go
@@ -353,12 +353,12 @@ func (s *Styles) RebuildStyles() {
 	s.HintSep = lipgloss.NewStyle().Foreground(s.Subtle)
 
 	s.CrumbActive = lipgloss.NewStyle().
-		Foreground(s.CrumbFgColor).
+		Foreground(s.Title).
 		Background(s.Highlight).
 		Bold(true).
 		Padding(0, 1)
 	s.CrumbAncestor = lipgloss.NewStyle().
-		Foreground(s.CrumbFgColor).
+		Foreground(s.Title).
 		Background(s.Highlight).
 		Padding(0, 1)
 	s.CrumbSep = lipgloss.NewStyle().Foreground(s.Subtle)

--- a/internal/color/styles.go
+++ b/internal/color/styles.go
@@ -354,12 +354,12 @@ func (s *Styles) RebuildStyles() {
 
 	s.CrumbActive = lipgloss.NewStyle().
 		Foreground(s.CrumbFgColor).
-		Background(s.CrumbBgColor).
+		Background(s.Highlight).
 		Bold(true).
 		Padding(0, 1)
 	s.CrumbAncestor = lipgloss.NewStyle().
 		Foreground(s.CrumbFgColor).
-		Background(s.CrumbBgAltColor).
+		Background(s.Highlight).
 		Padding(0, 1)
 	s.CrumbSep = lipgloss.NewStyle().Foreground(s.Subtle)
 

--- a/internal/color/styles.go
+++ b/internal/color/styles.go
@@ -246,7 +246,7 @@ func defaultPalette() palette {
 		muted:             lipgloss.Color("#5c6370"),
 		hintKey:           lipgloss.Color("#e5c07b"),
 		hintDesc:          lipgloss.Color("#5c6370"),
-		crumbFg:           lipgloss.Color("#282c34"),
+		crumbFg:           lipgloss.Color("#abb2bf"),
 		crumbBg:           lipgloss.Color("#61afef"),
 		border:            lipgloss.Color("#4b5263"),
 		borderTitle:       lipgloss.Color("#61afef"),
@@ -353,12 +353,12 @@ func (s *Styles) RebuildStyles() {
 	s.HintSep = lipgloss.NewStyle().Foreground(s.Subtle)
 
 	s.CrumbActive = lipgloss.NewStyle().
-		Foreground(s.Title).
+		Foreground(s.CrumbFgColor).
 		Background(s.Highlight).
 		Bold(true).
 		Padding(0, 1)
 	s.CrumbAncestor = lipgloss.NewStyle().
-		Foreground(s.Title).
+		Foreground(s.CrumbFgColor).
 		Background(s.Highlight).
 		Padding(0, 1)
 	s.CrumbSep = lipgloss.NewStyle().Foreground(s.Subtle)


### PR DESCRIPTION
## Summary

- Use the highlighted row background color for both active and ancestor breadcrumb pills
- Change default CrumbFgColor from #282c34 to #abb2bf for readability on the highlight background