### PR TITLE
fix: use ANSI red for ERROR/CRITICAL log severity

### DIFF
--- a/internal/view/debuglog/format.go
+++ b/internal/view/debuglog/format.go
@@ -41,7 +41,7 @@ func highlightSearchMatch(line, query string, s *color.Styles) string {
 func severityColor(severity string, s *color.Styles) lipgloss.Style {
 	switch strings.ToUpper(severity) {
 	case "ERROR", "CRITICAL":
-		return lipgloss.NewStyle().Foreground(s.CheckRedColor)
+		return lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(1)).Bold(true)
 	case "WARNING":
 		return lipgloss.NewStyle().Foreground(s.StatusColor("waiting"))
 	case "INFO":


### PR DESCRIPTION
## Summary
- Switch ERROR/CRITICAL severity color from hex `#e06c75` to `lipgloss.ANSIColor(1)` (standard ANSI red) + bold
- Ensures red rendering in any terminal color mode (the hex color could appear grey in some modes)