### PR TITLE
feat: live filtering with match highlighting across all table views

### DIFF
--- a/internal/app/input.go
+++ b/internal/app/input.go
@@ -107,6 +107,12 @@ func (m Model) updateInput(msg tea.Msg) (Model, tea.Cmd) {
 		}
 	}
 
+	// Apply filter live while typing.
+	if m.mode == modeFilter {
+		m.filterStr = m.input.Value()
+		m.applyFilterToActiveView()
+	}
+
 	return m, cmd
 }
 

--- a/internal/app/navigate.go
+++ b/internal/app/navigate.go
@@ -15,6 +15,10 @@ func (m Model) handleNavigate(msg view.NavigateMsg) (Model, tea.Cmd) {
 		return m, m.showToast(fmt.Sprintf("unknown view: %v", msg.Target))
 	}
 
+	// Clear any leftover filter from the previous view.
+	m.filterStr = ""
+	m.applyFilterToActiveView()
+
 	// Snapshot the stack before mutating so we can roll back if Enter fails.
 	snap := m.stack.Snapshot()
 
@@ -58,6 +62,7 @@ func (m Model) handleBack() (Model, tea.Cmd) {
 
 		// Clear any leftover filter from the child view.
 		m.filterStr = ""
+		m.applyFilterToActiveView()
 
 		current := m.stack.Current()
 		// Re-size the view we are returning to so it uses the correct contentHeight.

--- a/internal/view/appconfig/types.go
+++ b/internal/view/appconfig/types.go
@@ -10,11 +10,12 @@ import (
 
 // View is the Bubble Tea model for the application config table view.
 type View struct {
-	table   table.Model
-	keys    ui.KeyMap
-	styles  *color.Styles
-	width   int
-	height  int
-	appName string
-	entries []model.ConfigEntry
+	table     table.Model
+	keys      ui.KeyMap
+	styles    *color.Styles
+	width     int
+	height    int
+	appName   string
+	entries   []model.ConfigEntry
+	filterStr string
 }

--- a/internal/view/appconfig/view.go
+++ b/internal/view/appconfig/view.go
@@ -67,7 +67,7 @@ func (v *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if cfgMsg, ok := msg.(AppConfigMsg); ok {
 		if cfgMsg.AppName == v.appName {
 			v.entries = cfgMsg.Entries
-			v.table.SetRows(rows(v.entries))
+			v.rebuildRows()
 		}
 		return v, nil
 	}
@@ -102,3 +102,14 @@ func (v *View) Enter(ctx view.NavigateContext) (tea.Cmd, error) {
 }
 
 func (v *View) Leave() tea.Cmd { return nil }
+
+// SetFilter implements view.Filterable.
+func (v *View) SetFilter(filter string) {
+	v.filterStr = filter
+	v.rebuildRows()
+}
+
+func (v *View) rebuildRows() {
+	allRows := rows(v.entries)
+	v.table.SetRows(view.FilterRows(allRows, 0, v.filterStr, v.styles.SearchHighlight))
+}

--- a/internal/view/applications/types.go
+++ b/internal/view/applications/types.go
@@ -18,6 +18,8 @@ type View struct {
 	height int
 	status *model.FullStatus
 
+	filterStr string
+
 	deployModalOpen bool
 	deployModal     deploymodal.Modal
 

--- a/internal/view/applications/view.go
+++ b/internal/view/applications/view.go
@@ -38,9 +38,21 @@ func (a *View) SetSize(width, height int) {
 // SetStatus implements view.StatusReceiver.
 func (a *View) SetStatus(status *model.FullStatus) {
 	a.status = status
-	if status != nil {
-		a.table.SetRows(rows(status.Applications, a.styles))
+	a.rebuildRows()
+}
+
+// SetFilter implements view.Filterable.
+func (a *View) SetFilter(filter string) {
+	a.filterStr = filter
+	a.rebuildRows()
+}
+
+func (a *View) rebuildRows() {
+	if a.status == nil {
+		return
 	}
+	allRows := rows(a.status.Applications, a.styles)
+	a.table.SetRows(view.FilterRows(allRows, 0, a.filterStr, a.styles.SearchHighlight))
 }
 
 // SetCharmSuggestions stores external charm suggestions for deploy modal.

--- a/internal/view/controllers/types.go
+++ b/internal/view/controllers/types.go
@@ -23,4 +23,5 @@ type View struct {
 	height      int
 	controllers []model.Controller
 	pollFn      func() tea.Cmd
+	filterStr   string
 }

--- a/internal/view/controllers/view.go
+++ b/internal/view/controllers/view.go
@@ -37,7 +37,18 @@ func (c *View) SetSize(width, height int) {
 // SetControllers updates the controller list.
 func (c *View) SetControllers(ctrls []model.Controller) {
 	c.controllers = ctrls
-	c.table.SetRows(controllerRows(ctrls))
+	c.rebuildRows()
+}
+
+// SetFilter implements view.Filterable.
+func (c *View) SetFilter(filter string) {
+	c.filterStr = filter
+	c.rebuildRows()
+}
+
+func (c *View) rebuildRows() {
+	allRows := controllerRows(c.controllers)
+	c.table.SetRows(view.FilterRows(allRows, 0, c.filterStr, c.styles.SearchHighlight))
 }
 
 // KeyHints returns the view-specific key hints for the header.

--- a/internal/view/machines/types.go
+++ b/internal/view/machines/types.go
@@ -10,10 +10,11 @@ import (
 
 // View is the Bubble Tea model for the machines table view.
 type View struct {
-	table  table.Model
-	keys   ui.KeyMap
-	styles *color.Styles
-	width  int
-	height int
-	status *model.FullStatus
+	table     table.Model
+	keys      ui.KeyMap
+	styles    *color.Styles
+	width     int
+	height    int
+	status    *model.FullStatus
+	filterStr string
 }

--- a/internal/view/machines/view.go
+++ b/internal/view/machines/view.go
@@ -36,9 +36,21 @@ func (m *View) SetSize(width, height int) {
 // SetStatus implements view.StatusReceiver.
 func (m *View) SetStatus(status *model.FullStatus) {
 	m.status = status
-	if status != nil {
-		m.table.SetRows(machineRows(status.Machines))
+	m.rebuildRows()
+}
+
+// SetFilter implements view.Filterable.
+func (m *View) SetFilter(filter string) {
+	m.filterStr = filter
+	m.rebuildRows()
+}
+
+func (m *View) rebuildRows() {
+	if m.status == nil {
+		return
 	}
+	allRows := machineRows(m.status.Machines)
+	m.table.SetRows(view.FilterRows(allRows, 0, m.filterStr, m.styles.SearchHighlight))
 }
 
 // KeyHints returns the view-specific key hints for the header.

--- a/internal/view/models/types.go
+++ b/internal/view/models/types.go
@@ -25,4 +25,5 @@ type View struct {
 	pollFn             func(controller string) tea.Cmd
 	selectControllerFn func(name string) error
 	controllerNameFn   func() string
+	filterStr          string
 }

--- a/internal/view/models/view.go
+++ b/internal/view/models/view.go
@@ -37,7 +37,18 @@ func (m *View) SetSize(width, height int) {
 // SetModels updates the displayed model list.
 func (m *View) SetModels(mdls []model.ModelSummary) {
 	m.models = mdls
-	m.table.SetRows(modelRows(mdls))
+	m.rebuildRows()
+}
+
+// SetFilter implements view.Filterable.
+func (m *View) SetFilter(filter string) {
+	m.filterStr = filter
+	m.rebuildRows()
+}
+
+func (m *View) rebuildRows() {
+	allRows := modelRows(m.models)
+	m.table.SetRows(view.FilterRows(allRows, 0, m.filterStr, m.styles.SearchHighlight))
 }
 
 // KeyHints returns the view-specific key hints for the header.

--- a/internal/view/modelview/types.go
+++ b/internal/view/modelview/types.go
@@ -24,6 +24,7 @@ type View struct {
 	height       int
 	selectedApp  string
 	pendingScale map[string]int
+	filterStr    string
 
 	deployModalOpen bool
 	deployModal     deploymodal.Modal

--- a/internal/view/modelview/view.go
+++ b/internal/view/modelview/view.go
@@ -69,7 +69,7 @@ func (m *View) SetStatus(status *model.FullStatus) {
 	if status == nil {
 		return
 	}
-	m.appTable.SetRows(applicationRows(status.Applications, m.styles))
+	m.rebuildAppRows()
 	for appName, delta := range m.pendingScale {
 		app, ok := status.Applications[appName]
 		if !ok {
@@ -87,6 +87,21 @@ func (m *View) SetStatus(status *model.FullStatus) {
 		}
 	}
 	m.refreshRightPane()
+}
+
+// SetFilter implements view.Filterable.
+func (m *View) SetFilter(filter string) {
+	m.filterStr = filter
+	m.rebuildAppRows()
+	m.refreshRightPane()
+}
+
+func (m *View) rebuildAppRows() {
+	if m.status == nil {
+		return
+	}
+	allRows := applicationRows(m.status.Applications, m.styles)
+	m.appTable.SetRows(view.FilterRows(allRows, 0, m.filterStr, m.styles.SearchHighlight))
 }
 
 // SetCharmSuggestions stores external charm suggestions for deploy modal.

--- a/internal/view/offers/types.go
+++ b/internal/view/offers/types.go
@@ -19,11 +19,13 @@ type OffersDataMsg struct {
 
 // View is the Bubble Tea model for the offers table view.
 type View struct {
-	table   table.Model
-	keys    ui.KeyMap
-	styles  *color.Styles
-	width   int
-	height  int
-	err     error
-	hasData bool
+	table     table.Model
+	keys      ui.KeyMap
+	styles    *color.Styles
+	width     int
+	height    int
+	err       error
+	hasData   bool
+	offers    []model.Offer
+	filterStr string
 }

--- a/internal/view/offers/view.go
+++ b/internal/view/offers/view.go
@@ -45,7 +45,8 @@ func (v *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		v.err = nil
 		v.hasData = true
-		v.table.SetRows(Rows(dataMsg.Offers))
+		v.offers = dataMsg.Offers
+		v.rebuildRows()
 		return v, nil
 	}
 
@@ -72,3 +73,14 @@ func (v *View) Enter(_ view.NavigateContext) (tea.Cmd, error) {
 }
 
 func (v *View) Leave() tea.Cmd { return nil }
+
+// SetFilter implements view.Filterable.
+func (v *View) SetFilter(filter string) {
+	v.filterStr = filter
+	v.rebuildRows()
+}
+
+func (v *View) rebuildRows() {
+	allRows := Rows(v.offers)
+	v.table.SetRows(view.FilterRows(allRows, 0, v.filterStr, v.styles.SearchHighlight))
+}

--- a/internal/view/secrets/types.go
+++ b/internal/view/secrets/types.go
@@ -10,10 +10,11 @@ import (
 
 // View is the Bubble Tea model for the secrets table view.
 type View struct {
-	table  table.Model
-	keys   ui.KeyMap
-	styles *color.Styles
-	width  int
-	height int
-	status *model.FullStatus
+	table     table.Model
+	keys      ui.KeyMap
+	styles    *color.Styles
+	width     int
+	height    int
+	status    *model.FullStatus
+	filterStr string
 }

--- a/internal/view/secrets/view.go
+++ b/internal/view/secrets/view.go
@@ -36,9 +36,21 @@ func (s *View) SetSize(width, height int) {
 // SetStatus implements view.StatusReceiver.
 func (s *View) SetStatus(status *model.FullStatus) {
 	s.status = status
-	if status != nil {
-		s.table.SetRows(Rows(status.Secrets))
+	s.rebuildRows()
+}
+
+// SetFilter implements view.Filterable.
+func (s *View) SetFilter(filter string) {
+	s.filterStr = filter
+	s.rebuildRows()
+}
+
+func (s *View) rebuildRows() {
+	if s.status == nil {
+		return
 	}
+	allRows := Rows(s.status.Secrets)
+	s.table.SetRows(view.FilterRows(allRows, 0, s.filterStr, s.styles.SearchHighlight))
 }
 
 // KeyHints returns the view-specific key hints for the header.

--- a/internal/view/storage/types.go
+++ b/internal/view/storage/types.go
@@ -19,11 +19,13 @@ type StorageDataMsg struct {
 
 // View is the Bubble Tea model for the storage table view.
 type View struct {
-	table   table.Model
-	keys    ui.KeyMap
-	styles  *color.Styles
-	width   int
-	height  int
-	err     error
-	hasData bool
+	table     table.Model
+	keys      ui.KeyMap
+	styles    *color.Styles
+	width     int
+	height    int
+	err       error
+	hasData   bool
+	instances []model.StorageInstance
+	filterStr string
 }

--- a/internal/view/storage/view.go
+++ b/internal/view/storage/view.go
@@ -46,7 +46,8 @@ func (v *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		v.err = nil
 		v.hasData = true
-		v.table.SetRows(Rows(msg.Instances, v.styles))
+		v.instances = msg.Instances
+		v.rebuildRows()
 		return v, nil
 	}
 	var cmd tea.Cmd
@@ -72,3 +73,14 @@ func (v *View) Enter(_ view.NavigateContext) (tea.Cmd, error) {
 }
 
 func (v *View) Leave() tea.Cmd { return nil }
+
+// SetFilter implements view.Filterable.
+func (v *View) SetFilter(filter string) {
+	v.filterStr = filter
+	v.rebuildRows()
+}
+
+func (v *View) rebuildRows() {
+	allRows := Rows(v.instances, v.styles)
+	v.table.SetRows(view.FilterRows(allRows, 0, v.filterStr, v.styles.SearchHighlight))
+}

--- a/internal/view/units/types.go
+++ b/internal/view/units/types.go
@@ -19,6 +19,7 @@ type View struct {
 	status       *model.FullStatus
 	appName      string
 	pendingScale map[string]int // net pending unit delta per app
+	filterStr    string
 
 	actionModal     *actionmodal.Modal
 	actionModalOpen bool

--- a/internal/view/units/view.go
+++ b/internal/view/units/view.go
@@ -127,7 +127,13 @@ func (u *View) rebuildRows() {
 			}
 		}
 	}
-	u.table.SetRows(rows)
+	u.table.SetRows(view.FilterRows(rows, 0, u.filterStr, u.styles.SearchHighlight))
+}
+
+// SetFilter implements view.Filterable.
+func (u *View) SetFilter(filter string) {
+	u.filterStr = filter
+	u.rebuildRows()
 }
 
 func (u *View) Init() tea.Cmd { return nil }

--- a/internal/view/view.go
+++ b/internal/view/view.go
@@ -9,6 +9,9 @@ import (
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
 	"github.com/bschimke95/jara/internal/model"
 	"github.com/bschimke95/jara/internal/nav"
 	"github.com/bschimke95/jara/internal/ui"
@@ -200,6 +203,36 @@ func CopySelectedRow(t table.Model) string {
 		return strings.Join(row, "\t")
 	}
 	return ""
+}
+
+// FilterRows filters rows whose column at filterCol contains the filter string
+// (case-insensitive) and highlights the match in that column using the provided
+// highlight style. If filter is empty, all rows are returned unmodified.
+func FilterRows(allRows []table.Row, filterCol int, filter string, highlight lipgloss.Style) []table.Row {
+	if filter == "" {
+		return allRows
+	}
+	lower := strings.ToLower(filter)
+	var out []table.Row
+	for _, row := range allRows {
+		if filterCol >= len(row) {
+			continue
+		}
+		cell := row[filterCol]
+		plain := ansi.Strip(cell)
+		idx := strings.Index(strings.ToLower(plain), lower)
+		if idx < 0 {
+			continue
+		}
+		// Build a new row with highlight applied to the matched substring.
+		newRow := make(table.Row, len(row))
+		copy(newRow, row)
+		newRow[filterCol] = plain[:idx] +
+			highlight.Render(plain[idx:idx+len(filter)]) +
+			plain[idx+len(filter):]
+		out = append(out, newRow)
+	}
+	return out
 }
 
 // PadToHeight pads or truncates a rendered string so it has exactly the


### PR DESCRIPTION
## Summary
- Filter updates live while typing (no longer requires pressing Enter)
- All table views now implement `Filterable`, filtering by name/primary column (col 0)
- Filter matches are highlighted using the existing `SearchHighlight` style
- Filter is cleared automatically when navigating forward or back
- Added `FilterRows` helper in `view` package for consistent row filtering and highlighting
- ModelView filters the left-pane application table by app name

Views updated: applications, units, machines, secrets, offers, storage, controllers, models, appconfig, modelview. Relations already had filtering and is unchanged.