### PR TITLE
fix: Esc clears active filter before navigating back

### DIFF
--- a/internal/app/input.go
+++ b/internal/app/input.go
@@ -233,6 +233,12 @@ func (m Model) handleGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 		m2, cmd := m.quit()
 		return m2, cmd, true
 	case key.Matches(msg, m.keys.Back):
+		// If a filter is active, clear it instead of navigating back.
+		if m.filterStr != "" {
+			m.filterStr = ""
+			m.applyFilterToActiveView()
+			return m, nil, true
+		}
 		m2, cmd := m.handleBack()
 		return m2, cmd, true
 	case key.Matches(msg, m.keys.Command):


### PR DESCRIPTION
## Summary
- When a filter is active, pressing Esc clears it instead of navigating back
- A second Esc navigates back as usual (no filter to clear)