### PR TITLE
Fix action params, offers error handling, and toast duration

### DIFF
--- a/internal/api/mock.go
+++ b/internal/api/mock.go
@@ -396,7 +396,24 @@ func (c *MockClient) ApplicationActions(_ context.Context, appName string) ([]mo
 	}
 
 	return []model.ActionSpec{
-		{Name: "backup", Description: "Create a backup of the application data"},
+		{
+			Name:        "backup",
+			Description: "Create a backup of the application data",
+			Params: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"target": map[string]interface{}{
+						"type":        "string",
+						"description": "Backup target path",
+					},
+					"compress": map[string]interface{}{
+						"type":        "boolean",
+						"description": "Whether to compress the backup",
+						"default":     true,
+					},
+				},
+			},
+		},
 		{Name: "restart", Description: "Restart the application services"},
 		{Name: "get-password", Description: "Retrieve the admin password"},
 	}, nil

--- a/internal/app/statusstream.go
+++ b/internal/app/statusstream.go
@@ -325,7 +325,7 @@ func (m Model) fetchOffers() tea.Cmd {
 		defer cancel()
 		offerList, err := client.ListOffers(ctx)
 		if err != nil {
-			return errMsg{fmt.Errorf("fetching offers: %w", err)}
+			return offers.OffersDataMsg{Err: fmt.Errorf("fetching offers: %w", err)}
 		}
 		return offers.OffersDataMsg{Offers: offerList}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,7 @@ const (
 	DefaultCharmhubURL = "https://api.charmhub.io"
 
 	// DefaultToastDuration is the default duration for error toast messages.
-	DefaultToastDuration = 4 * time.Second
+	DefaultToastDuration = 7 * time.Second
 )
 
 // Config is the top-level configuration for jara.

--- a/internal/view/actionmodal/modal.go
+++ b/internal/view/actionmodal/modal.go
@@ -36,6 +36,9 @@ type CloseMsg struct{}
 type paramField struct {
 	Name        string
 	Description string
+	Type        string // e.g. "string", "integer", "boolean"
+	Default     string
+	Required    bool
 	Value       string
 }
 
@@ -390,11 +393,28 @@ func (m *Modal) renderParams(contentW int) string {
 		if i == m.paramCursor {
 			label = boldStyle.Render(label)
 		}
-		sb.WriteString(prefix + label)
-		if f.Description != "" {
-			sb.WriteString(mutedStyle.Render(" — " + truncate(f.Description, contentW-len(f.Name)-6)))
+
+		// Build metadata tags: (type) (required) (default: ...)
+		var tags []string
+		if f.Type != "" {
+			tags = append(tags, f.Type)
 		}
-		sb.WriteString("\n")
+		if f.Required {
+			tags = append(tags, "required")
+		}
+		if f.Default != "" {
+			tags = append(tags, "default: "+f.Default)
+		}
+		tagStr := ""
+		if len(tags) > 0 {
+			tagStr = mutedStyle.Render(" (" + strings.Join(tags, ", ") + ")")
+		}
+		sb.WriteString(prefix + label + tagStr + "\n")
+
+		// Show description on its own line if present.
+		if f.Description != "" {
+			sb.WriteString("    " + mutedStyle.Render(f.Description) + "\n")
+		}
 
 		// Show current value or input prompt.
 		val := f.Value
@@ -402,10 +422,15 @@ func (m *Modal) renderParams(contentW int) string {
 			val += "█"
 		}
 		if val == "" && (i != m.paramCursor || !m.paramEdit) {
-			sb.WriteString("    " + mutedStyle.Render("(empty)") + "\n")
+			placeholder := "(empty)"
+			if f.Default != "" {
+				placeholder = fmt.Sprintf("(default: %s)", f.Default)
+			}
+			sb.WriteString("    " + mutedStyle.Render(placeholder) + "\n")
 		} else {
 			sb.WriteString("    " + val + "\n")
 		}
+		sb.WriteString("\n")
 	}
 
 	// "Run" button.
@@ -424,19 +449,50 @@ func (m *Modal) renderParams(contentW int) string {
 }
 
 // buildParamFields extracts parameter names from a JSON-Schema style params map.
+// Juju action params follow JSON-Schema: the actual parameters live under the
+// "properties" key while top-level keys like "type", "title", "required" etc.
+// are schema metadata.
 func buildParamFields(params map[string]interface{}) []paramField {
-	fields := make([]paramField, 0, len(params))
-	for name, spec := range params {
-		desc := ""
-		if m, ok := spec.(map[string]interface{}); ok {
-			if d, ok := m["description"].(string); ok {
-				desc = d
+	props, hasProperties := params["properties"].(map[string]interface{})
+	if !hasProperties {
+		props = params
+	}
+
+	// Collect the set of required parameter names.
+	requiredSet := make(map[string]bool)
+	if reqList, ok := params["required"].([]interface{}); ok {
+		for _, r := range reqList {
+			if s, ok := r.(string); ok {
+				requiredSet[s] = true
 			}
 		}
-		fields = append(fields, paramField{
-			Name:        name,
-			Description: desc,
-		})
+	}
+
+	fields := make([]paramField, 0, len(props))
+	for name, spec := range props {
+		// Skip JSON-Schema meta keys that leaked into props when there
+		// was no "properties" wrapper.
+		switch name {
+		case "type", "title", "description", "required", "properties",
+			"additionalProperties", "$schema", "definitions":
+			if !hasProperties {
+				continue
+			}
+		}
+
+		f := paramField{Name: name, Required: requiredSet[name]}
+		if m, ok := spec.(map[string]interface{}); ok {
+			if d, ok := m["description"].(string); ok {
+				f.Description = d
+			}
+			if t, ok := m["type"].(string); ok {
+				f.Type = t
+			}
+			if d, ok := m["default"]; ok {
+				f.Default = fmt.Sprintf("%v", d)
+			}
+		}
+		fields = append(fields, f)
 	}
 	sort.Slice(fields, func(i, j int) bool {
 		return fields[i].Name < fields[j].Name


### PR DESCRIPTION
## Summary
- **Action params**: Parse JSON-Schema `properties` key correctly instead of treating top-level schema metadata (`type`, `required`, etc.) as parameter names. Show type, required flag, and default value for each parameter field.
- **Offers view**: Route fetch errors to the view via `OffersDataMsg.Err` so container model errors display persistently in the view instead of a brief toast that leaves the view stuck on "Loading offers..."
- **Toast duration**: Increase default from 4s to 7s for better readability