### PR TITLE
Enrich info modal: per-unit messages, skip empty fields

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -41,6 +41,9 @@ type ApplicationClient interface {
 	ApplicationActions(ctx context.Context, appName string) ([]model.ActionSpec, error)
 	// RunAction executes a named action on a unit and waits for the result.
 	RunAction(ctx context.Context, unitName, actionName string, params map[string]string) (*model.ActionResult, error)
+	// RemoveUnit removes a specific unit by name. When force is true the unit
+	// is removed even if it is in an error state.
+	RemoveUnit(ctx context.Context, unitName string, force bool) error
 }
 
 // RelationClient groups operations for managing relations between applications.

--- a/internal/api/juju.go
+++ b/internal/api/juju.go
@@ -614,6 +614,26 @@ func (c *JujuClient) ScaleApplication(ctx context.Context, appName string, delta
 	return nil
 }
 
+// RemoveUnit removes a single unit by name. When force is true, the unit is
+// removed even if it is in an error state.
+func (c *JujuClient) RemoveUnit(ctx context.Context, unitName string, force bool) error {
+	conn, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	appClient := application.NewClient(conn)
+	params := application.DestroyUnitsParams{
+		Units: []string{unitName},
+		Force: force,
+	}
+	_, err = appClient.DestroyUnits(ctx, params)
+	if err != nil {
+		return fmt.Errorf("removing unit %q: %w", unitName, err)
+	}
+	return nil
+}
+
 // DeployApplication deploys a charm from the configured repository into the
 // current model.
 func (c *JujuClient) DeployApplication(ctx context.Context, opts model.DeployOptions) error {

--- a/internal/api/mock.go
+++ b/internal/api/mock.go
@@ -245,6 +245,29 @@ func (c *MockClient) ScaleApplication(_ context.Context, appName string, delta i
 	return nil
 }
 
+// RemoveUnit removes a specific unit from the mock status.
+func (c *MockClient) RemoveUnit(_ context.Context, unitName string, _ bool) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Find which application owns this unit.
+	for appName, app := range c.status.Applications {
+		for i, u := range app.Units {
+			if u.Name == unitName {
+				delete(c.status.Machines, u.Machine)
+				app.Units = append(app.Units[:i], app.Units[i+1:]...)
+				app.Scale--
+				if app.Scale < 0 {
+					app.Scale = 0
+				}
+				c.status.Applications[appName] = app
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("unit %q not found", unitName)
+}
+
 // DeployApplication adds a new synthetic application to the current status.
 func (c *MockClient) DeployApplication(_ context.Context, opts model.DeployOptions) error {
 	c.mu.Lock()

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -415,6 +415,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case view.ScaleRequestMsg:
 		return m, m.scaleApplication(msg.AppName, msg.Delta)
 
+	case view.RemoveUnitRequestMsg:
+		return m, m.removeUnit(msg.UnitName, msg.Force)
+
 	case view.DeployRequestMsg:
 		return m, m.deployApplication(msg.ModelName, msg.Options)
 

--- a/internal/app/statusstream.go
+++ b/internal/app/statusstream.go
@@ -231,6 +231,23 @@ func (m Model) scaleApplication(appName string, delta int) tea.Cmd {
 	}
 }
 
+// removeUnit returns a Cmd that removes a specific unit.
+func (m Model) removeUnit(unitName string, force bool) tea.Cmd {
+	client := m.client
+	cfg := m.cfg
+	return func() tea.Msg {
+		if cfg != nil && cfg.Jara.ReadOnly {
+			return errMsg{fmt.Errorf("write operations are disabled in read-only mode")}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if err := client.RemoveUnit(ctx, unitName, force); err != nil {
+			return errMsg{err}
+		}
+		return nil
+	}
+}
+
 // deployApplication returns a Cmd that deploys a new application charm.
 // If modelName is set, deployment is targeted to that model first.
 func (m Model) deployApplication(modelName string, opts model.DeployOptions) tea.Cmd {

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -47,6 +47,7 @@ type KeyMap struct {
 	ConfigNav       key.Binding // C: view application config
 	Yank            key.Binding // y: copy selected row to clipboard
 	Inspect         key.Binding // i: show detail info for selected row
+	RemoveUnit      key.Binding // r: remove selected unit
 }
 
 // DefaultKeyMap returns the default vim-style keybindings.
@@ -215,6 +216,10 @@ func DefaultKeyMap() KeyMap {
 		Inspect: key.NewBinding(
 			key.WithKeys("i"),
 			key.WithHelp("i", "info"),
+		),
+		RemoveUnit: key.NewBinding(
+			key.WithKeys("r"),
+			key.WithHelp("r", "remove unit"),
 		),
 	}
 }

--- a/internal/view/applications/view.go
+++ b/internal/view/applications/view.go
@@ -3,7 +3,6 @@ package applications
 
 import (
 	"fmt"
-	"strings"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/table"
@@ -241,29 +240,46 @@ func (a *View) InspectSelection() *view.InspectData {
 	if !ok {
 		return nil
 	}
-	unitNames := make([]string, 0, len(app.Units))
-	for _, u := range app.Units {
-		unitNames = append(unitNames, u.Name)
-	}
 	since := ""
 	if app.Since != nil {
 		since = app.Since.Format("2006-01-02 15:04:05")
 	}
-	return &view.InspectData{
-		Title: name,
-		Fields: []view.InspectField{
-			{Label: "Name", Value: app.Name},
-			{Label: "Status", Value: app.Status},
-			{Label: "Status Message", Value: app.StatusMessage},
-			{Label: "Charm", Value: app.Charm},
-			{Label: "Channel", Value: app.CharmChannel},
-			{Label: "Revision", Value: fmt.Sprintf("%d", app.CharmRev)},
-			{Label: "Scale", Value: fmt.Sprintf("%d", app.Scale)},
-			{Label: "Exposed", Value: fmt.Sprintf("%v", app.Exposed)},
-			{Label: "Workload Version", Value: app.WorkloadVersion},
-			{Label: "Base", Value: app.Base},
-			{Label: "Since", Value: since},
-			{Label: "Units", Value: strings.Join(unitNames, ", ")},
-		},
+	fields := []view.InspectField{
+		{Label: "Name", Value: app.Name},
+		{Label: "Status", Value: app.Status},
+		{Label: "Status Message", Value: app.StatusMessage},
+		{Label: "Charm", Value: app.Charm},
+		{Label: "Channel", Value: app.CharmChannel},
+		{Label: "Revision", Value: fmt.Sprintf("%d", app.CharmRev)},
+		{Label: "Scale", Value: fmt.Sprintf("%d", app.Scale)},
+		{Label: "Exposed", Value: fmt.Sprintf("%v", app.Exposed)},
+		{Label: "Workload Version", Value: app.WorkloadVersion},
+		{Label: "Base", Value: app.Base},
+		{Label: "Since", Value: since},
 	}
+	// Append per-unit detail so the full workload/agent messages are visible.
+	for _, u := range app.Units {
+		fields = appendUnitFields(fields, u)
+		for _, sub := range u.Subordinates {
+			fields = appendUnitFields(fields, sub)
+		}
+	}
+	return &view.InspectData{
+		Title:  name,
+		Fields: fields,
+	}
+}
+
+func appendUnitFields(fields []view.InspectField, u model.Unit) []view.InspectField {
+	leader := ""
+	if u.Leader {
+		leader = "*"
+	}
+	fields = append(fields, view.InspectField{
+		Label: fmt.Sprintf("── %s %s", u.Name, leader),
+		Value: fmt.Sprintf("%s: %s | agent: %s: %s",
+			u.WorkloadStatus, u.WorkloadMessage,
+			u.AgentStatus, u.AgentMessage),
+	})
+	return fields
 }

--- a/internal/view/infomodal/modal.go
+++ b/internal/view/infomodal/modal.go
@@ -99,6 +99,9 @@ func (m *Modal) Render(background string) string {
 
 	var lines []string
 	for _, f := range m.data.Fields {
+		if f.Value == "" || f.Value == "0" {
+			continue
+		}
 		lines = append(lines, labelStyle.Render(f.Label))
 		// Word-wrap the value to contentW.
 		wrapped := wordWrap(f.Value, contentW-2)

--- a/internal/view/modelview/view.go
+++ b/internal/view/modelview/view.go
@@ -77,13 +77,18 @@ func (m *View) SetStatus(status *model.FullStatus) {
 			delete(m.pendingScale, appName)
 			continue
 		}
-		if delta < 0 {
-			if len(app.Units) <= app.Scale {
+		remaining := app.Scale - len(app.Units)
+		if delta > 0 {
+			if remaining <= 0 {
 				delete(m.pendingScale, appName)
+			} else if remaining < delta {
+				m.pendingScale[appName] = remaining
 			}
 		} else {
-			if len(app.Units) >= app.Scale {
+			if remaining >= 0 {
 				delete(m.pendingScale, appName)
+			} else if remaining > delta {
+				m.pendingScale[appName] = remaining
 			}
 		}
 	}

--- a/internal/view/modelview/view.go
+++ b/internal/view/modelview/view.go
@@ -78,18 +78,10 @@ func (m *View) SetStatus(status *model.FullStatus) {
 			continue
 		}
 		remaining := app.Scale - len(app.Units)
-		if delta > 0 {
-			if remaining <= 0 {
-				delete(m.pendingScale, appName)
-			} else if remaining < delta {
-				m.pendingScale[appName] = remaining
-			}
+		if remaining <= 0 || remaining >= delta {
+			delete(m.pendingScale, appName)
 		} else {
-			if remaining >= 0 {
-				delete(m.pendingScale, appName)
-			} else if remaining > delta {
-				m.pendingScale[appName] = remaining
-			}
+			m.pendingScale[appName] = remaining
 		}
 	}
 	m.refreshRightPane()
@@ -256,8 +248,6 @@ func (m *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.ScaleDown):
 			if m.selectedApp != "" {
 				app := m.selectedApp
-				m.pendingScale[app]--
-				m.refreshRightPane()
 				return m, func() tea.Msg { return view.ScaleRequestMsg{AppName: app, Delta: -1} }
 			}
 		case key.Matches(msg, m.keys.RunAction):
@@ -423,17 +413,9 @@ func (m *View) refreshRightPane() {
 
 	if app, ok := m.status.Applications[appName]; ok {
 		rows := units.CompactRowsForApp(app, m.styles)
-		if delta := m.pendingScale[appName]; delta != 0 {
+		if delta := m.pendingScale[appName]; delta > 0 {
 			pending := units.PendingCompactRows(appName, app.Units, delta, m.styles)
-			if delta < 0 {
-				tail := len(rows) - len(pending)
-				if tail < 0 {
-					tail = 0
-				}
-				rows = append(rows[:tail], pending...)
-			} else {
-				rows = append(rows, pending...)
-			}
+			rows = append(rows, pending...)
 		}
 		m.unitTable.SetRows(rows)
 	} else {

--- a/internal/view/units/rows.go
+++ b/internal/view/units/rows.go
@@ -116,49 +116,36 @@ func DetailRowsForApp(app model.Application, s *color.Styles) []table.Row {
 }
 
 // PendingCompactRows returns compact placeholder rows for the model-overview units pane.
+// Only scale-up (delta > 0) generates pseudo rows; scale-down is handled by
+// real status updates from Juju as units transition to dying/terminating.
 func PendingCompactRows(appName string, currentUnits []model.Unit, delta int, s *color.Styles) []table.Row {
-	var rows []table.Row
-	if delta > 0 {
-		nextIdx := len(currentUnits)
-		for range delta {
-			name := s.Pending.Render(fmt.Sprintf("  %s/%d", appName, nextIdx))
-			rows = append(rows, table.Row{name, s.Pending.Render("allocating"), s.Pending.Render("allocating"), s.Pending.Render("installing agent")})
-			nextIdx++
-		}
-	} else if delta < 0 {
-		n := -delta
-		start := len(currentUnits) - n
-		if start < 0 {
-			start = 0
-		}
-		for _, u := range currentUnits[start:] {
-			name := s.Pending.Render("  " + u.Name + " (removing)")
-			rows = append(rows, table.Row{name, s.Pending.Render("terminating"), s.Pending.Render("terminating"), ""})
-		}
+	if delta <= 0 {
+		return nil
+	}
+	rows := make([]table.Row, 0, delta)
+	nextIdx := len(currentUnits)
+	for range delta {
+		name := s.Pending.Render(fmt.Sprintf("  %s/%d", appName, nextIdx))
+		rows = append(rows, table.Row{name, s.Pending.Render("allocating"), s.Pending.Render("allocating"), s.Pending.Render("installing agent")})
+		nextIdx++
 	}
 	return rows
 }
 
 // PendingDetailRows returns full-column placeholder rows for the standalone units view.
+// PendingDetailRows returns full-column placeholder rows for the standalone units view.
+// Only scale-up (delta > 0) generates pseudo rows; scale-down is handled by
+// real status updates from Juju as units transition to dying/terminating.
 func PendingDetailRows(appName string, currentUnits []model.Unit, delta int, s *color.Styles) []table.Row {
-	var rows []table.Row
-	if delta > 0 {
-		nextIdx := len(currentUnits)
-		for range delta {
-			name := s.Pending.Render(fmt.Sprintf("  %s/%d", appName, nextIdx))
-			rows = append(rows, table.Row{name, s.Pending.Render("allocating"), s.Pending.Render("allocating"), "", "", "", s.Pending.Render("waiting for unit…")})
-			nextIdx++
-		}
-	} else if delta < 0 {
-		n := -delta
-		start := len(currentUnits) - n
-		if start < 0 {
-			start = 0
-		}
-		for _, u := range currentUnits[start:] {
-			name := s.Pending.Render("  " + u.Name + " (removing)")
-			rows = append(rows, table.Row{name, s.Pending.Render("terminating"), s.Pending.Render("terminating"), u.Machine, u.PublicAddress, "", s.Pending.Render("waiting for removal…")})
-		}
+	if delta <= 0 {
+		return nil
+	}
+	rows := make([]table.Row, 0, delta)
+	nextIdx := len(currentUnits)
+	for range delta {
+		name := s.Pending.Render(fmt.Sprintf("  %s/%d", appName, nextIdx))
+		rows = append(rows, table.Row{name, s.Pending.Render("allocating"), s.Pending.Render("allocating"), "", "", "", s.Pending.Render("waiting for unit…")})
+		nextIdx++
 	}
 	return rows
 }

--- a/internal/view/units/rows_test.go
+++ b/internal/view/units/rows_test.go
@@ -97,7 +97,7 @@ func TestPendingCompactRows(t *testing.T) {
 		wantRows int
 	}{
 		{name: "scale up by 2", units: nil, delta: 2, wantRows: 2},
-		{name: "scale down by 1", units: []model.Unit{{Name: "app/0"}, {Name: "app/1"}}, delta: -1, wantRows: 1},
+		{name: "scale down by 1", units: []model.Unit{{Name: "app/0"}, {Name: "app/1"}}, delta: -1, wantRows: 0},
 		{name: "no change", units: nil, delta: 0, wantRows: 0},
 	}
 	for _, tt := range tests {
@@ -118,7 +118,7 @@ func TestPendingDetailRows(t *testing.T) {
 		wantRows int
 	}{
 		{name: "scale up by 3", units: nil, delta: 3, wantRows: 3},
-		{name: "scale down by 2", units: []model.Unit{{Name: "app/0"}, {Name: "app/1"}, {Name: "app/2"}}, delta: -2, wantRows: 2},
+		{name: "scale down by 2", units: []model.Unit{{Name: "app/0"}, {Name: "app/1"}, {Name: "app/2"}}, delta: -2, wantRows: 0},
 		{name: "no change", units: nil, delta: 0, wantRows: 0},
 	}
 	for _, tt := range tests {

--- a/internal/view/units/types.go
+++ b/internal/view/units/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bschimke95/jara/internal/model"
 	"github.com/bschimke95/jara/internal/ui"
 	"github.com/bschimke95/jara/internal/view/actionmodal"
+	"github.com/bschimke95/jara/internal/view/confirmodal"
 )
 
 // View is the Bubble Tea model for the units table view.
@@ -23,4 +24,9 @@ type View struct {
 
 	actionModal     *actionmodal.Modal
 	actionModalOpen bool
+
+	confirmModal confirmodal.Modal
+	confirmOpen  bool
+	removingUnit string // unit name pending removal
+	removeForce  bool   // force-remove toggle
 }

--- a/internal/view/units/view.go
+++ b/internal/view/units/view.go
@@ -297,12 +297,10 @@ func (u *View) Leave() tea.Cmd { return nil }
 
 // InspectSelection implements view.Inspectable.
 func (u *View) InspectSelection() *view.InspectData {
-	row := u.table.SelectedRow()
-	if row == nil || u.status == nil {
+	unitName := u.selectedUnitName()
+	if unitName == "" || u.status == nil {
 		return nil
 	}
-	unitName := ansi.Strip(row[0])
-	// Find the unit in the status.
 	for _, app := range u.status.Applications {
 		for _, unit := range app.Units {
 			if unit.Name == unitName {

--- a/internal/view/units/view.go
+++ b/internal/view/units/view.go
@@ -44,20 +44,25 @@ func (u *View) SetStatus(status *model.FullStatus) {
 	if status == nil {
 		return
 	}
-	// Reconcile pending scale: clear entries where live unit count has caught up.
+	// Reconcile pending scale: reduce deltas as live unit count catches up.
 	for appName, delta := range u.pendingScale {
 		app, ok := status.Applications[appName]
 		if !ok {
 			delete(u.pendingScale, appName)
 			continue
 		}
-		if delta < 0 {
-			if len(app.Units) <= app.Scale {
+		remaining := app.Scale - len(app.Units)
+		if delta > 0 {
+			if remaining <= 0 {
 				delete(u.pendingScale, appName)
+			} else if remaining < delta {
+				u.pendingScale[appName] = remaining
 			}
 		} else {
-			if len(app.Units) >= app.Scale {
+			if remaining >= 0 {
 				delete(u.pendingScale, appName)
+			} else if remaining > delta {
+				u.pendingScale[appName] = remaining
 			}
 		}
 	}

--- a/internal/view/units/view.go
+++ b/internal/view/units/view.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bschimke95/jara/internal/ui"
 	"github.com/bschimke95/jara/internal/view"
 	"github.com/bschimke95/jara/internal/view/actionmodal"
+	"github.com/bschimke95/jara/internal/view/confirmodal"
 )
 
 // New creates a new units view. If appName is non-empty, only that app's units are shown.
@@ -52,18 +53,10 @@ func (u *View) SetStatus(status *model.FullStatus) {
 			continue
 		}
 		remaining := app.Scale - len(app.Units)
-		if delta > 0 {
-			if remaining <= 0 {
-				delete(u.pendingScale, appName)
-			} else if remaining < delta {
-				u.pendingScale[appName] = remaining
-			}
+		if remaining <= 0 || remaining >= delta {
+			delete(u.pendingScale, appName)
 		} else {
-			if remaining >= 0 {
-				delete(u.pendingScale, appName)
-			} else if remaining > delta {
-				u.pendingScale[appName] = remaining
-			}
+			u.pendingScale[appName] = remaining
 		}
 	}
 	u.rebuildRows()
@@ -74,6 +67,7 @@ func (u *View) KeyHints() []view.KeyHint {
 	return []view.KeyHint{
 		{Key: view.BindingKey(u.keys.Inspect), Desc: "info"},
 		{Key: view.BindingKey(u.keys.RunAction), Desc: "action"},
+		{Key: view.BindingKey(u.keys.RemoveUnit), Desc: "remove"},
 		{Key: view.BindingKey(u.keys.ScaleUp) + "/" + view.BindingKey(u.keys.ScaleDown), Desc: "scale"},
 		{Key: view.BindingKey(u.keys.LogsJump), Desc: "logs (unit)"},
 	}
@@ -93,45 +87,20 @@ func (u *View) rebuildRows() {
 	if u.appName != "" {
 		if app, ok := u.status.Applications[u.appName]; ok {
 			rows = DetailRowsForApp(app, u.styles)
-			if delta := u.pendingScale[u.appName]; delta != 0 {
+			if delta := u.pendingScale[u.appName]; delta > 0 {
 				pending := PendingDetailRows(u.appName, app.Units, delta, u.styles)
-				if delta < 0 {
-					tail := len(rows) - len(pending)
-					if tail < 0 {
-						tail = 0
-					}
-					rows = append(rows[:tail], pending...)
-				} else {
-					rows = append(rows, pending...)
-				}
+				rows = append(rows, pending...)
 			}
 		}
 	} else {
 		rows = DetailRows(u.status.Applications, u.styles)
 		for appName, delta := range u.pendingScale {
-			if delta == 0 {
+			if delta <= 0 {
 				continue
 			}
 			app := u.status.Applications[appName]
 			pending := PendingDetailRows(appName, app.Units, delta, u.styles)
-			if delta < 0 {
-				prefix := "  " + appName + "/"
-				end := -1
-				for i, r := range rows {
-					if strings.Contains(r[0], prefix) {
-						end = i + 1
-					}
-				}
-				if end >= 0 {
-					start := end - len(pending)
-					if start < 0 {
-						start = 0
-					}
-					rows = append(rows[:start], append(pending, rows[end:]...)...)
-				}
-			} else {
-				rows = append(rows, pending...)
-			}
+			rows = append(rows, pending...)
 		}
 	}
 	u.table.SetRows(view.FilterRows(rows, 0, u.filterStr, u.styles.SearchHighlight))
@@ -146,6 +115,36 @@ func (u *View) SetFilter(filter string) {
 func (u *View) Init() tea.Cmd { return nil }
 
 func (u *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// ── Confirm modal takes priority ──
+	if u.confirmOpen {
+		switch msg := msg.(type) {
+		case confirmodal.ConfirmedMsg:
+			u.confirmOpen = false
+			name, force := u.removingUnit, u.removeForce
+			u.removingUnit = ""
+			u.removeForce = false
+			return u, func() tea.Msg {
+				return view.RemoveUnitRequestMsg{UnitName: name, Force: force}
+			}
+		case confirmodal.CancelledMsg:
+			u.confirmOpen = false
+			u.removingUnit = ""
+			u.removeForce = false
+			return u, nil
+		default:
+			if kp, ok := msg.(tea.KeyPressMsg); ok && kp.String() == "f" {
+				u.removeForce = !u.removeForce
+				u.confirmModal = u.buildRemoveConfirmModal()
+				return u, nil
+			}
+			updated, cmd := u.confirmModal.Update(msg)
+			if cm, ok := updated.(*confirmodal.Modal); ok {
+				u.confirmModal = *cm
+			}
+			return u, cmd
+		}
+	}
+
 	// When the action modal is open, delegate all messages to it.
 	if u.actionModalOpen {
 		switch msg := msg.(type) {
@@ -173,8 +172,6 @@ func (u *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, u.keys.ScaleDown):
 			appName := u.selectedAppName()
 			if appName != "" {
-				u.pendingScale[appName]--
-				u.rebuildRows()
 				return u, func() tea.Msg { return view.ScaleRequestMsg{AppName: appName, Delta: -1} }
 			}
 		case key.Matches(msg, u.keys.LogsJump):
@@ -205,6 +202,15 @@ func (u *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				u.actionModal = m
 				u.actionModalOpen = true
 				return u, m.Init()
+			}
+		case key.Matches(msg, u.keys.RemoveUnit):
+			unitName := u.selectedUnitName()
+			if unitName != "" {
+				u.removingUnit = unitName
+				u.removeForce = false
+				u.confirmModal = u.buildRemoveConfirmModal()
+				u.confirmOpen = true
+				return u, nil
 			}
 		}
 	}
@@ -271,10 +277,25 @@ func (u *View) View() tea.View {
 		}()
 	}
 	tableView := u.table.View()
+	if u.confirmOpen {
+		return tea.NewView(u.confirmModal.Render(tableView))
+	}
 	if u.actionModalOpen && u.actionModal != nil {
 		return tea.NewView(u.actionModal.Render(tableView))
 	}
 	return tea.NewView(tableView)
+}
+
+// buildRemoveConfirmModal creates the confirmation modal for unit removal.
+func (u *View) buildRemoveConfirmModal() confirmodal.Modal {
+	forceLabel := "off"
+	if u.removeForce {
+		forceLabel = "ON"
+	}
+	msg := fmt.Sprintf("Remove unit %s?\n\n[f] force: %s", u.removingUnit, forceLabel)
+	m := confirmodal.New(u.keys, u.styles, "Remove Unit", msg)
+	m.SetSize(u.width, u.height)
+	return m
 }
 
 func (u *View) Enter(ctx view.NavigateContext) (tea.Cmd, error) {

--- a/internal/view/view.go
+++ b/internal/view/view.go
@@ -43,6 +43,12 @@ type ScaleRequestMsg struct {
 	Delta   int
 }
 
+// RemoveUnitRequestMsg requests removal of a specific unit.
+type RemoveUnitRequestMsg struct {
+	UnitName string
+	Force    bool
+}
+
 // DeployRequestMsg requests deploying a charm with the provided options.
 // ModelName is optional; when set, deployment should target that model.
 type DeployRequestMsg struct {


### PR DESCRIPTION
## Summary

- Application inspect modal now includes per-unit workload/agent status and full message text, so truncated errors like `container error: ...` are fully readable without navigating to the units view
- Empty fields are hidden across all inspect views to reduce noise