### PR TITLE
feat: add entity switch modal (s key) for filtering views by application

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -31,6 +31,7 @@ import (
 	"github.com/bschimke95/jara/internal/view/secretdetail"
 	"github.com/bschimke95/jara/internal/view/secrets"
 	"github.com/bschimke95/jara/internal/view/storage"
+	"github.com/bschimke95/jara/internal/view/switchmodal"
 	"github.com/bschimke95/jara/internal/view/units"
 )
 
@@ -53,13 +54,15 @@ type Model struct {
 	suggestions        []nav.CommandMatch
 	selectedSuggestion int
 
-	keys          ui.KeyMap
-	width         int
-	height        int
-	helpModalOpen bool
-	helpModal     helpmodal.Modal
-	infoModalOpen bool
-	infoModal     *infomodal.Modal
+	keys            ui.KeyMap
+	width           int
+	height          int
+	helpModalOpen   bool
+	helpModal       helpmodal.Modal
+	infoModalOpen   bool
+	infoModal       *infomodal.Modal
+	switchModalOpen bool
+	switchModal     *switchmodal.Modal
 
 	statusCancel context.CancelFunc      // cancels the status stream
 	statusCh     <-chan api.StatusUpdate // receives status snapshots
@@ -387,6 +390,32 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// ── Switch modal: owns all keys when open ──
+	if m.switchModalOpen {
+		switch msg := msg.(type) {
+		case switchmodal.SelectedMsg:
+			m.switchModalOpen = false
+			m.switchModal = nil
+			return m.switchEntityContext(msg.Entity)
+		case switchmodal.PreviewMsg:
+			return m.switchEntityContext(msg.Entity)
+		case switchmodal.ClosedMsg:
+			m.switchModalOpen = false
+			m.switchModal = nil
+			// Restore the original entity if the user cancelled.
+			return m.switchEntityContext(msg.Original)
+		default:
+			if _, ok := msg.(tea.KeyPressMsg); ok {
+				updated, cmd := m.switchModal.Update(msg)
+				if sm, ok := updated.(*switchmodal.Modal); ok {
+					m.switchModal = sm
+				}
+				return m, cmd
+			}
+			return m, nil
+		}
+	}
+
 	// ── Delegate to the active view ──
 	// Views get priority so they can override global key bindings
 	// (e.g. the debug-log view handles '/' for in-buffer search).
@@ -623,6 +652,11 @@ func (m Model) View() tea.View {
 	// ── Info modal overlay ──
 	if m.infoModalOpen && m.infoModal != nil {
 		return tea.NewView(m.infoModal.Render(body))
+	}
+
+	// ── Switch modal overlay ──
+	if m.switchModalOpen && m.switchModal != nil {
+		return tea.NewView(m.switchModal.Render(body))
 	}
 
 	// ── Help modal overlay ──

--- a/internal/app/input.go
+++ b/internal/app/input.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bschimke95/jara/internal/ui"
 	"github.com/bschimke95/jara/internal/view"
 	"github.com/bschimke95/jara/internal/view/infomodal"
+	"github.com/bschimke95/jara/internal/view/switchmodal"
 )
 
 type inputMode int
@@ -280,6 +281,18 @@ func (m Model) handleGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 				m.infoModal = infomodal.New(*data, m.keys, m.styles)
 				m.infoModal.SetSize(m.width, m.height)
 				m.infoModalOpen = true
+				return m, nil, true
+			}
+		}
+		return m, nil, true
+	case key.Matches(msg, m.keys.EntitySwitch):
+		currentView := m.views[m.stack.Current().View]
+		if es, ok := currentView.(view.EntitySwitchable); ok {
+			entities, current := es.SwitchableEntities()
+			if len(entities) > 0 {
+				m.switchModal = switchmodal.New(es.SwitchTitle(), entities, current, m.keys, m.styles)
+				m.switchModal.SetSize(m.width, m.height)
+				m.switchModalOpen = true
 				return m, nil, true
 			}
 		}

--- a/internal/app/navigate.go
+++ b/internal/app/navigate.go
@@ -51,6 +51,32 @@ func (m Model) handleNavigate(msg view.NavigateMsg) (Model, tea.Cmd) {
 	return m, nil
 }
 
+// switchEntityContext re-enters the current view with a new entity context.
+// An empty entity clears the filter (show all).
+func (m Model) switchEntityContext(entity string) (Model, tea.Cmd) {
+	current := m.stack.Current()
+	v := m.views[current.View]
+	if v == nil {
+		return m, nil
+	}
+
+	// Update the stack entry context.
+	m.stack.SetCurrentContext(entity)
+
+	v.SetSize(m.width, m.contentHeight())
+	if m.status != nil {
+		if sr, ok := v.(view.StatusReceiver); ok {
+			sr.SetStatus(m.status)
+		}
+	}
+
+	cmd, err := v.Enter(view.NavigateContext{Context: entity})
+	if err != nil {
+		return m, m.showToast(err.Error())
+	}
+	return m, cmd
+}
+
 func (m Model) handleBack() (Model, tea.Cmd) {
 	prev := m.stack.Current()
 	if _, ok := m.stack.Pop(); ok {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -217,6 +217,7 @@ type KeysConfig struct {
 	Left            *KeyBindingConfig `yaml:"left,omitempty"`
 	RunAction       *KeyBindingConfig `yaml:"runAction,omitempty"`
 	ConfigNav       *KeyBindingConfig `yaml:"configNav,omitempty"`
+	EntitySwitch    *KeyBindingConfig `yaml:"entitySwitch,omitempty"`
 }
 
 // NewDefault returns a Config with all compiled defaults.

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -51,6 +51,7 @@ func ResolveKeyMap(keys KeysConfig) ui.KeyMap {
 	overrideBinding(&km.Left, keys.Left, "left")
 	overrideBinding(&km.RunAction, keys.RunAction, "run action")
 	overrideBinding(&km.ConfigNav, keys.ConfigNav, "config")
+	overrideBinding(&km.EntitySwitch, keys.EntitySwitch, "switch entity")
 
 	return km
 }

--- a/internal/nav/nav.go
+++ b/internal/nav/nav.go
@@ -178,6 +178,14 @@ func (s *Stack) Current() StackEntry {
 	return s.entries[len(s.entries)-1]
 }
 
+// SetCurrentContext updates the context of the current (top) stack entry.
+func (s *Stack) SetCurrentContext(ctx string) {
+	if len(s.entries) == 0 {
+		panic("nav.Stack.SetCurrentContext called on empty stack")
+	}
+	s.entries[len(s.entries)-1].Context = ctx
+}
+
 // Breadcrumbs returns the display names of all entries in the stack.
 func (s *Stack) Breadcrumbs() []string {
 	crumbs := make([]string, len(s.entries))

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -47,6 +47,7 @@ type KeyMap struct {
 	ConfigNav       key.Binding // C: view application config
 	Yank            key.Binding // y: copy selected row to clipboard
 	Inspect         key.Binding // i: show detail info for selected row
+	EntitySwitch    key.Binding // s: switch entity context (e.g. filter by app)
 }
 
 // DefaultKeyMap returns the default vim-style keybindings.
@@ -215,6 +216,10 @@ func DefaultKeyMap() KeyMap {
 		Inspect: key.NewBinding(
 			key.WithKeys("i"),
 			key.WithHelp("i", "info"),
+		),
+		EntitySwitch: key.NewBinding(
+			key.WithKeys("s"),
+			key.WithHelp("s", "switch entity"),
 		),
 	}
 }

--- a/internal/view/appconfig/types.go
+++ b/internal/view/appconfig/types.go
@@ -18,4 +18,5 @@ type View struct {
 	appName   string
 	entries   []model.ConfigEntry
 	filterStr string
+	status    *model.FullStatus
 }

--- a/internal/view/appconfig/view.go
+++ b/internal/view/appconfig/view.go
@@ -3,6 +3,7 @@ package appconfig
 
 import (
 	"fmt"
+	"sort"
 
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
@@ -59,6 +60,7 @@ func (v *View) KeyHints() []view.KeyHint {
 		{Key: view.BindingKey(v.keys.Inspect), Desc: "info"},
 		{Key: view.BindingKey(v.keys.Back), Desc: "back"},
 		{Key: view.BindingKey(v.keys.Yank), Desc: "copy value"},
+		{Key: view.BindingKey(v.keys.EntitySwitch), Desc: "switch app"},
 	}
 }
 
@@ -103,6 +105,27 @@ func (v *View) Enter(ctx view.NavigateContext) (tea.Cmd, error) {
 }
 
 func (v *View) Leave() tea.Cmd { return nil }
+
+// SetStatus implements view.StatusReceiver.
+func (v *View) SetStatus(status *model.FullStatus) {
+	v.status = status
+}
+
+// SwitchTitle implements view.EntitySwitchable.
+func (v *View) SwitchTitle() string { return "Switch Application" }
+
+// SwitchableEntities implements view.EntitySwitchable.
+func (v *View) SwitchableEntities() ([]string, string) {
+	if v.status == nil {
+		return nil, v.appName
+	}
+	names := make([]string, 0, len(v.status.Applications))
+	for name := range v.status.Applications {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, v.appName
+}
 
 // SetFilter implements view.Filterable.
 func (v *View) SetFilter(filter string) {

--- a/internal/view/relations/types.go
+++ b/internal/view/relations/types.go
@@ -19,6 +19,9 @@ type View struct {
 	height int
 	status *model.FullStatus
 
+	// Entity switch: filter relations by application name.
+	appName string
+
 	// Search/filter state.
 	filterStr    string
 	filteredRels []model.Relation

--- a/internal/view/relations/view.go
+++ b/internal/view/relations/view.go
@@ -72,6 +72,7 @@ func (r *View) KeyHints() []view.KeyHint {
 		{Key: view.BindingKey(r.keys.Inspect), Desc: "info"},
 		{Key: view.BindingKey(r.keys.DeleteRelation), Desc: "delete"},
 		{Key: view.BindingKey(r.keys.LogsJump), Desc: "logs"},
+		{Key: view.BindingKey(r.keys.EntitySwitch), Desc: "switch app"},
 	}
 }
 
@@ -169,13 +170,37 @@ func (r *View) View() tea.View {
 	return tea.NewView(background)
 }
 
-func (r *View) Enter(_ view.NavigateContext) (tea.Cmd, error) {
+func (r *View) Enter(ctx view.NavigateContext) (tea.Cmd, error) {
+	r.appName = ctx.Context
+	r.applyFilter()
 	return r.requestRelationData(), nil
 }
 
 func (r *View) Leave() tea.Cmd {
 	r.relationData = nil
 	return nil
+}
+
+// SwitchTitle implements view.EntitySwitchable.
+func (r *View) SwitchTitle() string { return "Switch Application" }
+
+// SwitchableEntities implements view.EntitySwitchable.
+func (r *View) SwitchableEntities() ([]string, string) {
+	if r.status == nil {
+		return nil, r.appName
+	}
+	seen := make(map[string]bool)
+	for _, rel := range r.status.Relations {
+		for _, ep := range rel.Endpoints {
+			seen[ep.ApplicationName] = true
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names, r.appName
 }
 
 // FilterStr returns the current filter string.
@@ -243,21 +268,32 @@ func (r *View) applyFilter() {
 	}
 
 	var rels []model.Relation
-	if r.filterStr == "" {
-		rels = append(rels, r.status.Relations...)
-	} else {
-		lower := strings.ToLower(r.filterStr)
-		for _, rel := range r.status.Relations {
-			if matchesFilter(rel, lower) {
-				rels = append(rels, rel)
+	for _, rel := range r.status.Relations {
+		// Filter by app name if set.
+		if r.appName != "" && !relationInvolvesApp(rel, r.appName) {
+			continue
+		}
+		if r.filterStr != "" {
+			if !matchesFilter(rel, strings.ToLower(r.filterStr)) {
+				continue
 			}
 		}
+		rels = append(rels, rel)
 	}
 
 	sort.Slice(rels, func(i, j int) bool { return rels[i].ID < rels[j].ID })
 
 	r.filteredRels = rels
 	r.table.SetRows(Rows(rels))
+}
+
+func relationInvolvesApp(rel model.Relation, app string) bool {
+	for _, ep := range rel.Endpoints {
+		if ep.ApplicationName == app {
+			return true
+		}
+	}
+	return false
 }
 
 func matchesFilter(rel model.Relation, lower string) bool {

--- a/internal/view/secrets/types.go
+++ b/internal/view/secrets/types.go
@@ -17,4 +17,5 @@ type View struct {
 	height    int
 	status    *model.FullStatus
 	filterStr string
+	appName   string // entity switch: filter by owner application
 }

--- a/internal/view/secrets/view.go
+++ b/internal/view/secrets/view.go
@@ -3,6 +3,8 @@ package secrets
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/table"
@@ -51,7 +53,14 @@ func (s *View) rebuildRows() {
 	if s.status == nil {
 		return
 	}
-	allRows := Rows(s.status.Secrets)
+	var filtered []model.Secret
+	for _, sec := range s.status.Secrets {
+		if s.appName != "" && secretOwnerApp(sec.Owner) != s.appName {
+			continue
+		}
+		filtered = append(filtered, sec)
+	}
+	allRows := Rows(filtered)
 	s.table.SetRows(view.FilterRows(allRows, 0, s.filterStr, s.styles.SearchHighlight))
 }
 
@@ -61,6 +70,7 @@ func (s *View) KeyHints() []view.KeyHint {
 		{Key: view.BindingKey(s.keys.Enter), Desc: "detail"},
 		{Key: view.BindingKey(s.keys.Inspect), Desc: "info"},
 		{Key: view.BindingKey(s.keys.LogsView), Desc: "logs"},
+		{Key: view.BindingKey(s.keys.EntitySwitch), Desc: "switch app"},
 	}
 }
 
@@ -75,13 +85,10 @@ func (s *View) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if kp, ok := msg.(tea.KeyPressMsg); ok {
 		switch {
 		case key.Matches(kp, s.keys.Enter):
-			if s.status != nil && len(s.status.Secrets) > 0 {
-				idx := s.table.Cursor()
-				if idx >= 0 && idx < len(s.status.Secrets) {
-					uri := s.status.Secrets[idx].URI
-					return s, func() tea.Msg {
-						return view.NavigateMsg{Target: nav.SecretDetailView, Context: uri}
-					}
+			if row := s.table.SelectedRow(); row != nil {
+				uri := row[0]
+				return s, func() tea.Msg {
+					return view.NavigateMsg{Target: nav.SecretDetailView, Context: uri}
 				}
 			}
 		case key.Matches(kp, s.keys.LogsView):
@@ -99,19 +106,74 @@ func (s *View) View() tea.View {
 	return tea.NewView(s.table.View())
 }
 
-func (s *View) Enter(_ view.NavigateContext) (tea.Cmd, error) { return nil, nil }
-func (s *View) Leave() tea.Cmd                                { return nil }
+func (s *View) Enter(ctx view.NavigateContext) (tea.Cmd, error) {
+	s.appName = ctx.Context
+	s.rebuildRows()
+	return nil, nil
+}
+
+func (s *View) Leave() tea.Cmd { return nil }
+
+// SwitchTitle implements view.EntitySwitchable.
+func (s *View) SwitchTitle() string { return "Switch Application" }
+
+// SwitchableEntities implements view.EntitySwitchable.
+func (s *View) SwitchableEntities() ([]string, string) {
+	if s.status == nil {
+		return nil, s.appName
+	}
+	seen := make(map[string]bool)
+	for _, sec := range s.status.Secrets {
+		app := secretOwnerApp(sec.Owner)
+		if app != "" {
+			seen[app] = true
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names, s.appName
+}
+
+// secretOwnerApp extracts the application name from a secret owner string.
+// Owner is like "application-postgresql", "unit-mysql-0", or "model".
+func secretOwnerApp(owner string) string {
+	if strings.HasPrefix(owner, "application-") {
+		return owner[len("application-"):]
+	}
+	if strings.HasPrefix(owner, "unit-") {
+		rest := owner[5:]
+		if idx := strings.LastIndex(rest, "-"); idx > 0 {
+			return rest[:idx]
+		}
+	}
+	return owner
+}
 
 // InspectSelection implements view.Inspectable.
 func (s *View) InspectSelection() *view.InspectData {
 	if s.status == nil || len(s.status.Secrets) == 0 {
 		return nil
 	}
-	idx := s.table.Cursor()
-	if idx < 0 || idx >= len(s.status.Secrets) {
+	row := s.table.SelectedRow()
+	if row == nil {
 		return nil
 	}
-	sec := s.status.Secrets[idx]
+	uri := row[0]
+	var sec model.Secret
+	found := false
+	for _, sc := range s.status.Secrets {
+		if sc.URI == uri {
+			sec = sc
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
 	expire := ""
 	if sec.ExpireTime != nil {
 		expire = sec.ExpireTime.Format("2006-01-02 15:04:05")

--- a/internal/view/storage/types.go
+++ b/internal/view/storage/types.go
@@ -28,4 +28,6 @@ type View struct {
 	hasData   bool
 	instances []model.StorageInstance
 	filterStr string
+	appName   string // entity switch: filter by owner application
+	status    *model.FullStatus
 }

--- a/internal/view/storage/view.go
+++ b/internal/view/storage/view.go
@@ -3,11 +3,14 @@ package storage
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/bschimke95/jara/internal/color"
+	"github.com/bschimke95/jara/internal/model"
 	"github.com/bschimke95/jara/internal/ui"
 	"github.com/bschimke95/jara/internal/view"
 )
@@ -36,6 +39,7 @@ func (v *View) SetSize(width, height int) {
 func (v *View) KeyHints() []view.KeyHint {
 	return []view.KeyHint{
 		{Key: view.BindingKey(v.keys.Inspect), Desc: "info"},
+		{Key: view.BindingKey(v.keys.EntitySwitch), Desc: "switch app"},
 	}
 }
 
@@ -72,11 +76,51 @@ func (v *View) View() tea.View {
 	return tea.NewView(v.table.View())
 }
 
-func (v *View) Enter(_ view.NavigateContext) (tea.Cmd, error) {
+func (v *View) Enter(ctx view.NavigateContext) (tea.Cmd, error) {
+	v.appName = ctx.Context
 	return func() tea.Msg { return FetchStorageMsg{} }, nil
 }
 
 func (v *View) Leave() tea.Cmd { return nil }
+
+// SetStatus implements view.StatusReceiver.
+func (v *View) SetStatus(status *model.FullStatus) {
+	v.status = status
+}
+
+// SwitchTitle implements view.EntitySwitchable.
+func (v *View) SwitchTitle() string { return "Switch Application" }
+
+// SwitchableEntities implements view.EntitySwitchable.
+func (v *View) SwitchableEntities() ([]string, string) {
+	// Derive app names from storage owners (owner is like "unit-myapp-0" or "myapp").
+	seen := make(map[string]bool)
+	for _, si := range v.instances {
+		app := storageOwnerApp(si.Owner)
+		if app != "" {
+			seen[app] = true
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names, v.appName
+}
+
+// storageOwnerApp extracts the application name from a storage owner string.
+// Owner can be "unit-myapp-0" or just "myapp".
+func storageOwnerApp(owner string) string {
+	if strings.HasPrefix(owner, "unit-") {
+		// "unit-myapp-0" -> "myapp"
+		rest := owner[5:]
+		if idx := strings.LastIndex(rest, "-"); idx > 0 {
+			return rest[:idx]
+		}
+	}
+	return owner
+}
 
 // SetFilter implements view.Filterable.
 func (v *View) SetFilter(filter string) {
@@ -85,17 +129,36 @@ func (v *View) SetFilter(filter string) {
 }
 
 func (v *View) rebuildRows() {
-	allRows := Rows(v.instances, v.styles)
+	var filtered []model.StorageInstance
+	for _, si := range v.instances {
+		if v.appName != "" && storageOwnerApp(si.Owner) != v.appName {
+			continue
+		}
+		filtered = append(filtered, si)
+	}
+	allRows := Rows(filtered, v.styles)
 	v.table.SetRows(view.FilterRows(allRows, 0, v.filterStr, v.styles.SearchHighlight))
 }
 
 // InspectSelection implements view.Inspectable.
 func (v *View) InspectSelection() *view.InspectData {
-	idx := v.table.Cursor()
-	if idx < 0 || idx >= len(v.instances) {
+	row := v.table.SelectedRow()
+	if row == nil {
 		return nil
 	}
-	si := v.instances[idx]
+	id := row[0]
+	var si model.StorageInstance
+	found := false
+	for _, inst := range v.instances {
+		if inst.ID == id {
+			si = inst
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
 	return &view.InspectData{
 		Title: si.ID,
 		Fields: []view.InspectField{

--- a/internal/view/switchmodal/modal.go
+++ b/internal/view/switchmodal/modal.go
@@ -1,0 +1,188 @@
+// Package switchmodal implements a modal overlay for switching the active
+// entity context (e.g. selecting which application to filter by).
+package switchmodal
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/bschimke95/jara/internal/color"
+	"github.com/bschimke95/jara/internal/ui"
+)
+
+// SelectedMsg is emitted when the user confirms an entity.
+type SelectedMsg struct {
+	Entity string // empty string means "show all" (clear filter)
+}
+
+// PreviewMsg is emitted when the cursor moves to preview a different entity.
+type PreviewMsg struct {
+	Entity string
+}
+
+// ClosedMsg is emitted when the user dismisses the modal without choosing.
+type ClosedMsg struct {
+	Original string // the entity that was active when the modal opened
+}
+
+// Modal is a scrollable list overlay for picking an entity.
+type Modal struct {
+	keys   ui.KeyMap
+	styles *color.Styles
+	width  int
+	height int
+
+	title    string
+	items    []string // first entry is always "" (show all)
+	cursor   int
+	original string // entity active when the modal opened
+}
+
+// New creates a new switch modal. entities should be the available names
+// (sorted). current is the currently active entity (empty = show all).
+// title is shown in the modal border (e.g. "Switch Application").
+func New(title string, entities []string, current string, keys ui.KeyMap, styles *color.Styles) *Modal {
+	items := make([]string, 0, len(entities)+1)
+	items = append(items, "") // show all
+	items = append(items, entities...)
+
+	cursor := 0
+	for i, e := range items {
+		if e == current {
+			cursor = i
+			break
+		}
+	}
+
+	return &Modal{
+		keys:     keys,
+		styles:   styles,
+		title:    title,
+		items:    items,
+		cursor:   cursor,
+		original: current,
+	}
+}
+
+func (m *Modal) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+func (m *Modal) Init() tea.Cmd { return nil }
+
+func (m *Modal) View() tea.View {
+	return tea.NewView(m.Render(""))
+}
+
+func (m *Modal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	kp, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch {
+	case key.Matches(kp, m.keys.Enter):
+		return m, func() tea.Msg { return SelectedMsg{Entity: m.items[m.cursor]} }
+	case key.Matches(kp, m.keys.Back):
+		return m, func() tea.Msg { return ClosedMsg{Original: m.original} }
+	case key.Matches(kp, m.keys.Down):
+		if m.cursor < len(m.items)-1 {
+			m.cursor++
+			entity := m.items[m.cursor]
+			return m, func() tea.Msg { return PreviewMsg{Entity: entity} }
+		}
+	case key.Matches(kp, m.keys.Up):
+		if m.cursor > 0 {
+			m.cursor--
+			entity := m.items[m.cursor]
+			return m, func() tea.Msg { return PreviewMsg{Entity: entity} }
+		}
+	}
+
+	return m, nil
+}
+
+// Render draws the switch modal over the given background.
+func (m *Modal) Render(background string) string {
+	innerW := m.width * 40 / 100
+	if innerW < 30 {
+		innerW = 30
+	}
+	if innerW > 50 {
+		innerW = 50
+	}
+	contentW := innerW - 2
+
+	maxVisible := 10
+	if maxVisible > len(m.items) {
+		maxVisible = len(m.items)
+	}
+	start := m.cursor - maxVisible/2
+	if start < 0 {
+		start = 0
+	}
+	if start+maxVisible > len(m.items) {
+		start = len(m.items) - maxVisible
+	}
+
+	selectedStyle := lipgloss.NewStyle().
+		Foreground(m.styles.CrumbFgColor).
+		Background(m.styles.Highlight).
+		Bold(true).
+		Width(contentW)
+	normalStyle := lipgloss.NewStyle().
+		Foreground(m.styles.Title).
+		Width(contentW)
+	activeMarker := lipgloss.NewStyle().
+		Foreground(m.styles.Primary).
+		Bold(true)
+
+	var lines []string
+	for i := start; i < start+maxVisible; i++ {
+		label := m.items[i]
+		if label == "" {
+			label = "(show all)"
+		}
+
+		suffix := ""
+		if m.items[i] == m.original {
+			suffix = activeMarker.Render(" *")
+		}
+
+		if i == m.cursor {
+			lines = append(lines, selectedStyle.Render(" "+label)+suffix)
+		} else {
+			lines = append(lines, normalStyle.Render(" "+label)+suffix)
+		}
+	}
+
+	content := strings.Join(lines, "\n")
+
+	hintStyle := lipgloss.NewStyle().Foreground(m.styles.Muted).Width(contentW).AlignHorizontal(lipgloss.Center)
+	content += "\n" + hintStyle.Render("[enter] select  [esc] cancel")
+
+	titleStyle := lipgloss.NewStyle().Foreground(m.styles.BorderTitleColor).Bold(true)
+	box := ui.BorderBoxRawTitle(content, titleStyle.Render(" "+m.title+" "), innerW+4, m.styles)
+
+	modalH := lipgloss.Height(box)
+	x := (m.width - (innerW + 4)) / 2
+	y := (m.height - modalH) / 2
+	if x < 0 {
+		x = 0
+	}
+	if y < 0 {
+		y = 0
+	}
+
+	bg := background
+	if bg == "" {
+		bg = strings.Repeat("\n", m.height)
+	}
+	bgLayer := lipgloss.NewLayer(bg)
+	overlayLayer := lipgloss.NewLayer(box).X(x).Y(y).Z(1)
+	return lipgloss.NewCompositor(bgLayer, overlayLayer).Render()
+}

--- a/internal/view/units/view.go
+++ b/internal/view/units/view.go
@@ -3,6 +3,7 @@ package units
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -71,6 +72,7 @@ func (u *View) KeyHints() []view.KeyHint {
 		{Key: view.BindingKey(u.keys.RunAction), Desc: "action"},
 		{Key: view.BindingKey(u.keys.ScaleUp) + "/" + view.BindingKey(u.keys.ScaleDown), Desc: "scale"},
 		{Key: view.BindingKey(u.keys.LogsJump), Desc: "logs (unit)"},
+		{Key: view.BindingKey(u.keys.EntitySwitch), Desc: "switch app"},
 	}
 }
 
@@ -294,6 +296,22 @@ func (u *View) Enter(ctx view.NavigateContext) (tea.Cmd, error) {
 }
 
 func (u *View) Leave() tea.Cmd { return nil }
+
+// SwitchTitle implements view.EntitySwitchable.
+func (u *View) SwitchTitle() string { return "Switch Application" }
+
+// SwitchableEntities implements view.EntitySwitchable.
+func (u *View) SwitchableEntities() ([]string, string) {
+	if u.status == nil {
+		return nil, u.appName
+	}
+	names := make([]string, 0, len(u.status.Applications))
+	for name := range u.status.Applications {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, u.appName
+}
 
 // InspectSelection implements view.Inspectable.
 func (u *View) InspectSelection() *view.InspectData {

--- a/internal/view/view.go
+++ b/internal/view/view.go
@@ -198,6 +198,17 @@ type Inspectable interface {
 	InspectSelection() *InspectData
 }
 
+// EntitySwitchable is an optional interface for views that support switching
+// the active entity context (e.g. filtering units by application). Views
+// return the list of available entity names plus the currently active one.
+// An empty current value means no entity filter is active (show all).
+type EntitySwitchable interface {
+	// SwitchableEntities returns available entity names and the current selection.
+	SwitchableEntities() (entities []string, current string)
+	// SwitchTitle returns the modal title (e.g. "Switch Application").
+	SwitchTitle() string
+}
+
 // ClipboardMsg is sent when text has been copied to the clipboard.
 // The app uses this to show a brief notification.
 type ClipboardMsg struct {


### PR DESCRIPTION
## Summary
- Add `s` hotkey that opens a switch modal on views that support entity filtering (units, relations, secrets, storage, appconfig)
- Table updates live behind the modal as the cursor moves through the entity list
- Cancelling with `esc` restores the original selection
- Each view shows a contextual title (e.g. "Switch Application") and keyhint
- Fixes index-based `InspectSelection` in secrets and storage views to use row data lookup