### PR TITLE
feat: add release workflow with GoReleaser and snap stable publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: GoReleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  snap-stable:
+    name: Snap (stable)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
+
+      - name: Publish snap to latest/stable
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: latest/stable

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Snap
 jara*.snap
 
+# GoReleaser
+dist/
+
 # IDE
 .idea/
 .vscode/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,57 @@
+version: 2
+
+project_name: jara
+
+builds:
+  - main: ./cmd/jara
+    binary: jara
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -w -s
+      - -X github.com/bschimke95/jara/internal/cmd.version={{ .Version }}
+      - -X github.com/bschimke95/jara/internal/cmd.commit={{ .ShortCommit }}
+      - -X github.com/bschimke95/jara/internal/cmd.date={{ .Date }}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  use: github
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))?!?:.+$'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^.*?fix(\(.+\))?!?:.+$'
+      order: 1
+    - title: Refactoring
+      regexp: '^.*?refactor(\(.+\))?!?:.+$'
+      order: 2
+    - title: Other
+      order: 999
+  filters:
+    exclude:
+      - "^doc:"
+      - "^ci:"
+      - "^chore\\(deps\\):"
+      - "\\[skip ci\\]"
+
+release:
+  github:
+    owner: bschimke95
+    name: jara
+  prerelease: auto
+  name_template: "{{ .Tag }}"


### PR DESCRIPTION
## Summary
- add GoReleaser config for cross-compiled GitHub Releases (linux/darwin x amd64/arm64) with auto-generated changelog
- add release workflow triggered on `v*` tag push: GoReleaser for binaries + snap publish to `latest/stable`
- existing `latest/edge` snap publishing on main commits unchanged

## Usage
```
git tag v0.1.0
git push origin v0.1.0
```